### PR TITLE
feat(results): responsive multi-reel slot machine

### DIFF
--- a/lib/screens/results/results_screen.dart
+++ b/lib/screens/results/results_screen.dart
@@ -24,7 +24,7 @@ class ResultsScreen extends ConsumerStatefulWidget {
 }
 
 class _ResultsScreenState extends ConsumerState<ResultsScreen> {
-  final GlobalKey<SlotMachineListState> _slotMachineKey = GlobalKey();
+  final GlobalKey<MultiReelSlotMachineState> _slotMachineKey = GlobalKey();
   bool _showCelebration = false;
   List<SavedRegion> _regions = [];
 
@@ -322,7 +322,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
   }
 
   Widget _buildSlotMachineList(BuildContext context, DiscoveryState state) {
-    return SlotMachineList(
+    return MultiReelSlotMachine(
       key: _slotMachineKey,
       restaurants: state.restaurants,
       onRestaurantTap: _onDirectTap,

--- a/lib/widgets/multi_reel_slot_machine.dart
+++ b/lib/widgets/multi_reel_slot_machine.dart
@@ -1,0 +1,309 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:randoeats/config/config.dart';
+import 'package:randoeats/models/models.dart';
+import 'package:randoeats/widgets/reel_layout.dart';
+import 'package:randoeats/widgets/restaurant_card.dart';
+import 'package:randoeats/widgets/slot_machine_list.dart' show OnRestaurantTap;
+
+/// A responsive, multi-reel slot machine.
+///
+/// The number of reels is derived from the *measured* available width
+/// ([ReelLayout.columnsForWidth]) — 1 on phones, more on tablets/foldables —
+/// and the reels fill the width with no leftover gutter. On a spin, all reels
+/// scroll and stop one-by-one (left → right); a single random winning cell is
+/// then highlighted and reported via [onSpinComplete].
+class MultiReelSlotMachine extends StatefulWidget {
+  /// Creates a [MultiReelSlotMachine].
+  const MultiReelSlotMachine({
+    required this.restaurants,
+    required this.onRestaurantTap,
+    required this.onSpinComplete,
+    this.maxColumns = 3,
+    super.key,
+  });
+
+  /// Restaurants to display/spin through (repeated across cells if few).
+  final List<Restaurant> restaurants;
+
+  /// Direct tap on a (non-spinning) cell.
+  final OnRestaurantTap onRestaurantTap;
+
+  /// Called once all reels stop, with the winning restaurant.
+  final OnRestaurantTap onSpinComplete;
+
+  /// Upper bound on reel count (3 by default — fits an iPad in landscape).
+  final int maxColumns;
+
+  @override
+  State<MultiReelSlotMachine> createState() => MultiReelSlotMachineState();
+}
+
+/// State for [MultiReelSlotMachine]; exposes [spin] and [isSpinning].
+class MultiReelSlotMachineState extends State<MultiReelSlotMachine> {
+  static const double cardHeight = 176;
+  static const Duration _baseSpin = Duration(milliseconds: 2600);
+  static const Duration _stagger = Duration(milliseconds: 450);
+
+  final _random = math.Random();
+  final List<GlobalKey<_ReelState>> _reelKeys = [];
+
+  int _columns = 1;
+  int _rows = 1;
+  bool _isSpinning = false;
+  int? _winnerColumn;
+  int _stoppedCount = 0;
+
+  /// Whether a spin is in progress.
+  bool get isSpinning => _isSpinning;
+
+  int _rowsFor(double height) {
+    if (!height.isFinite || height <= 0) return 4;
+    // A couple extra rows beyond the viewport so each reel has travel to spin.
+    return math.max(3, (height / cardHeight).ceil() + 2);
+  }
+
+  void _syncReelKeys(int columns) {
+    while (_reelKeys.length < columns) {
+      _reelKeys.add(GlobalKey<_ReelState>());
+    }
+    if (_reelKeys.length > columns) {
+      _reelKeys.removeRange(columns, _reelKeys.length);
+    }
+  }
+
+  /// Spins every reel; stops them left→right; reveals one winning cell.
+  void spin() {
+    if (_isSpinning || widget.restaurants.isEmpty) return;
+    setState(() {
+      _isSpinning = true;
+      _winnerColumn = null;
+      _stoppedCount = 0;
+    });
+
+    final winnerColumn = _random.nextInt(_columns);
+    for (var c = 0; c < _columns; c++) {
+      _reelKeys[c].currentState?.spin(
+        duration: _baseSpin + _stagger * c,
+        onStopped: () => _onReelStopped(winnerColumn),
+      );
+    }
+  }
+
+  void _onReelStopped(int winnerColumn) {
+    _stoppedCount++;
+    if (_stoppedCount < _columns) return;
+
+    final reels = ReelLayout.buildReels(
+      widget.restaurants,
+      columns: _columns,
+      rows: _rows,
+    );
+    final landed = _reelKeys[winnerColumn].currentState?.landedIndex ?? 0;
+    final winner = reels[winnerColumn][landed];
+
+    setState(() {
+      _isSpinning = false;
+      _winnerColumn = winnerColumn;
+    });
+    widget.onSpinComplete(winner);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final columns = ReelLayout.columnsForWidth(
+          constraints.maxWidth,
+          maxColumns: widget.maxColumns,
+        );
+        final rows = _rowsFor(constraints.maxHeight);
+        // Cache derived layout so spin() and the next build agree.
+        _columns = columns;
+        _rows = rows;
+        _syncReelKeys(columns);
+
+        final reels = ReelLayout.buildReels(
+          widget.restaurants,
+          columns: columns,
+          rows: rows,
+        );
+
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (var c = 0; c < columns; c++)
+              Expanded(
+                child: _Reel(
+                  key: _reelKeys[c],
+                  restaurants: reels[c],
+                  cardHeight: cardHeight,
+                  isWinner: _winnerColumn == c,
+                  dimmed: _winnerColumn != null && _winnerColumn != c,
+                  spinning: _isSpinning,
+                  onCardTap: widget.onRestaurantTap,
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// A single vertical reel of restaurant cards with its own spin animation.
+class _Reel extends StatefulWidget {
+  const _Reel({
+    required this.restaurants,
+    required this.cardHeight,
+    required this.isWinner,
+    required this.dimmed,
+    required this.spinning,
+    required this.onCardTap,
+    super.key,
+  });
+
+  final List<Restaurant> restaurants;
+  final double cardHeight;
+  final bool isWinner;
+  final bool dimmed;
+  final bool spinning;
+  final OnRestaurantTap onCardTap;
+
+  @override
+  State<_Reel> createState() => _ReelState();
+}
+
+class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
+  final ScrollController _scroll = ScrollController();
+  late final AnimationController _controller;
+  Animation<double>? _animation;
+
+  int landedIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    // Create eagerly while the element is active. A lazy `late` initializer
+    // would otherwise run inside dispose() for reels that never spin, doing an
+    // ancestor (TickerMode) lookup on a deactivated element → crash.
+    _controller = AnimationController(vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// Spins this reel for [duration], landing a random cell at the top.
+  void spin({required Duration duration, required VoidCallback onStopped}) {
+    if (widget.restaurants.isEmpty) {
+      onStopped();
+      return;
+    }
+    landedIndex = math.Random().nextInt(widget.restaurants.length);
+
+    final cycle = widget.restaurants.length * widget.cardHeight;
+    final target = (cycle * 3) + (landedIndex * widget.cardHeight);
+
+    if (_scroll.hasClients) _scroll.jumpTo(0);
+    _controller
+      ..duration = duration
+      ..reset();
+    _animation = Tween<double>(begin: 0, end: target).animate(
+      CurvedAnimation(parent: _controller, curve: _SlotMachineCurve()),
+    )..addListener(_tick);
+
+    void statusListener(AnimationStatus status) {
+      if (status != AnimationStatus.completed) return;
+      _animation?.removeListener(_tick);
+      _controller.removeStatusListener(statusListener);
+      if (_scroll.hasClients) {
+        final maxExtent = _scroll.position.maxScrollExtent;
+        _scroll.jumpTo((landedIndex * widget.cardHeight).clamp(0, maxExtent));
+      }
+      onStopped();
+    }
+
+    _controller.addStatusListener(statusListener);
+    unawaited(_controller.forward());
+  }
+
+  void _tick() {
+    if (!_scroll.hasClients) return;
+    final maxExtent = _scroll.position.maxScrollExtent;
+    final wrapped = _animation!.value % (maxExtent + widget.cardHeight);
+    _scroll.jumpTo(wrapped.clamp(0, maxExtent));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedOpacity(
+      duration: const Duration(milliseconds: 250),
+      opacity: widget.dimmed ? 0.35 : 1,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          border: widget.isWinner
+              ? Border.all(color: GoogieColors.coral, width: 3)
+              : null,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: ListView.builder(
+          key: const ValueKey('reel_list'),
+          controller: _scroll,
+          physics: widget.spinning
+              ? const NeverScrollableScrollPhysics()
+              : const ClampingScrollPhysics(),
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          itemCount: widget.restaurants.length,
+          itemBuilder: (context, index) {
+            final restaurant = widget.restaurants[index];
+            final isWinnerCell =
+                widget.isWinner && index == landedIndex && !widget.spinning;
+            return Stack(
+              children: [
+                RestaurantCard(
+                  key: ValueKey('reel_cell_${restaurant.placeId}_$index'),
+                  restaurant: restaurant,
+                  index: index,
+                  onTap: widget.spinning
+                      ? () {}
+                      : () => widget.onCardTap(restaurant),
+                ),
+                if (isWinnerCell)
+                  Positioned.fill(
+                    child: IgnorePointer(
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          border: Border.all(
+                            color: GoogieColors.mustard,
+                            width: 4,
+                          ),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+/// Slot-machine easing: quick start, full speed, decelerate to a stop.
+class _SlotMachineCurve extends Curve {
+  @override
+  double transform(double t) {
+    if (t < 0.1) return Curves.easeIn.transform(t * 10) * 0.1;
+    if (t < 0.6) return 0.1 + (t - 0.1) * (0.6 / 0.5);
+    final localT = (t - 0.6) / 0.4;
+    return 0.7 + Curves.easeOutCubic.transform(localT) * 0.3;
+  }
+}

--- a/lib/widgets/reel_layout.dart
+++ b/lib/widgets/reel_layout.dart
@@ -1,0 +1,46 @@
+import 'package:randoeats/models/models.dart';
+
+/// Pure layout helpers for the responsive multi-reel slot machine.
+///
+/// Width is *measured* (via `LayoutBuilder` at the call site) and the column
+/// count is derived from it — never from device model — so the grid fills the
+/// available width on phones, foldables, tablets, and split-screen alike.
+abstract final class ReelLayout {
+  /// Target width per reel. Columns = floor(availableWidth / this), so cells
+  /// stretch to fill the measured width with no leftover gutter.
+  static const double targetReelWidth = 340;
+
+  /// Number of reels (columns) for [width], clamped to [1, maxColumns].
+  static int columnsForWidth(double width, {int maxColumns = 3}) {
+    if (width <= 0 || !width.isFinite) return 1;
+    final columns = (width / targetReelWidth).floor();
+    return columns.clamp(1, maxColumns);
+  }
+
+  /// Distributes [restaurants] into [columns] reels of [rows] cells each.
+  ///
+  /// When there are fewer restaurants than cells, restaurants repeat to fill
+  /// (duplicates across cells are allowed by design). Returns `columns` lists,
+  /// each of length `rows` (empty lists when [restaurants] is empty).
+  static List<List<Restaurant>> buildReels(
+    List<Restaurant> restaurants, {
+    required int columns,
+    required int rows,
+  }) {
+    final reels = List.generate(
+      columns,
+      (_) => <Restaurant>[],
+      growable: false,
+    );
+    if (restaurants.isEmpty || columns <= 0 || rows <= 0) return reels;
+
+    var index = 0;
+    for (var c = 0; c < columns; c++) {
+      for (var r = 0; r < rows; r++) {
+        reels[c].add(restaurants[index % restaurants.length]);
+        index++;
+      }
+    }
+    return reels;
+  }
+}

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -1,7 +1,9 @@
 /// Widgets for rand-o-eats.
 library;
 
+export 'multi_reel_slot_machine.dart';
 export 'rando_eats_button.dart';
+export 'reel_layout.dart';
 export 'region_chip_bar.dart';
 export 'restaurant_card.dart';
 export 'slot_machine_list.dart';

--- a/test/screens/results_screen_test.dart
+++ b/test/screens/results_screen_test.dart
@@ -100,7 +100,7 @@ void main() {
         ),
       );
 
-      expect(find.byType(SlotMachineList), findsOneWidget);
+      expect(find.byType(MultiReelSlotMachine), findsOneWidget);
       expect(find.byType(RandoEatsButton), findsOneWidget);
     });
 

--- a/test/widgets/multi_reel_slot_machine_test.dart
+++ b/test/widgets/multi_reel_slot_machine_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:randoeats/models/models.dart';
+import 'package:randoeats/widgets/multi_reel_slot_machine.dart';
+
+void main() {
+  List<Restaurant> makeRestaurants(int n) => List.generate(
+    n,
+    (i) => Restaurant(
+      placeId: 'p$i',
+      name: 'R$i',
+      address: 'addr $i',
+      latitude: 0,
+      longitude: 0,
+      isOpen: true,
+    ),
+  );
+
+  Future<void> pumpMachine(
+    WidgetTester tester, {
+    required Size size,
+    required GlobalKey<MultiReelSlotMachineState> machineKey,
+    required List<Restaurant> restaurants,
+    void Function(Restaurant)? onWin,
+  }) async {
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = size;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MultiReelSlotMachine(
+            key: machineKey,
+            restaurants: restaurants,
+            onRestaurantTap: (_) {},
+            onSpinComplete: onWin ?? (_) {},
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('shows 1 reel on a phone-width surface', (tester) async {
+    await pumpMachine(
+      tester,
+      size: const Size(390, 844),
+      machineKey: GlobalKey<MultiReelSlotMachineState>(),
+      restaurants: makeRestaurants(10),
+    );
+    expect(find.byType(ListView), findsOneWidget); // one reel = one ListView
+  });
+
+  testWidgets('shows 3 reels on a wide (landscape iPad) surface', (
+    tester,
+  ) async {
+    await pumpMachine(
+      tester,
+      size: const Size(1366, 1024),
+      machineKey: GlobalKey<MultiReelSlotMachineState>(),
+      restaurants: makeRestaurants(20),
+    );
+    expect(find.byType(ListView), findsNWidgets(3));
+  });
+
+  testWidgets('shows 2 reels on iPad portrait', (tester) async {
+    await pumpMachine(
+      tester,
+      size: const Size(834, 1112),
+      machineKey: GlobalKey<MultiReelSlotMachineState>(),
+      restaurants: makeRestaurants(20),
+    );
+    expect(find.byType(ListView), findsNWidgets(2));
+  });
+
+  testWidgets('spin reports a winner drawn from the list', (tester) async {
+    final machineKey = GlobalKey<MultiReelSlotMachineState>();
+    final restaurants = makeRestaurants(20);
+    Restaurant? winner;
+
+    await pumpMachine(
+      tester,
+      size: const Size(1100, 900),
+      machineKey: machineKey,
+      restaurants: restaurants,
+      onWin: (r) => winner = r,
+    );
+
+    machineKey.currentState!.spin();
+    expect(machineKey.currentState!.isSpinning, isTrue);
+
+    await tester.pumpAndSettle(const Duration(seconds: 12));
+
+    expect(winner, isNotNull);
+    expect(
+      restaurants.map((r) => r.placeId),
+      contains(winner!.placeId),
+    );
+    expect(machineKey.currentState!.isSpinning, isFalse);
+  });
+
+  testWidgets('does nothing on spin with no restaurants', (tester) async {
+    final machineKey = GlobalKey<MultiReelSlotMachineState>();
+    await pumpMachine(
+      tester,
+      size: const Size(800, 800),
+      machineKey: machineKey,
+      restaurants: const [],
+    );
+    machineKey.currentState!.spin();
+    expect(machineKey.currentState!.isSpinning, isFalse);
+  });
+}

--- a/test/widgets/reel_layout_test.dart
+++ b/test/widgets/reel_layout_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:randoeats/models/models.dart';
+import 'package:randoeats/widgets/reel_layout.dart';
+
+void main() {
+  group('ReelLayout.columnsForWidth', () {
+    test('phone widths get 1 column', () {
+      expect(ReelLayout.columnsForWidth(390), 1);
+      expect(ReelLayout.columnsForWidth(0), 1);
+      expect(ReelLayout.columnsForWidth(-5), 1);
+      expect(ReelLayout.columnsForWidth(double.infinity), 1);
+    });
+
+    test('tablet portrait gets 2 columns', () {
+      expect(ReelLayout.columnsForWidth(768), 2);
+      expect(ReelLayout.columnsForWidth(1024), 3); // 1024/340 = 3.01 -> 3
+    });
+
+    test('clamps to maxColumns', () {
+      expect(ReelLayout.columnsForWidth(4000), 3);
+      expect(ReelLayout.columnsForWidth(4000, maxColumns: 4), 4);
+    });
+
+    test('is driven purely by width / target (no device assumptions)', () {
+      // Just over 2x target -> 2; just over 3x -> 3.
+      expect(ReelLayout.columnsForWidth(ReelLayout.targetReelWidth * 2 + 1), 2);
+      expect(ReelLayout.columnsForWidth(ReelLayout.targetReelWidth * 3 + 1), 3);
+      expect(ReelLayout.columnsForWidth(ReelLayout.targetReelWidth - 1), 1);
+    });
+  });
+
+  group('ReelLayout.buildReels', () {
+    List<Restaurant> makeRestaurants(int n) => List.generate(
+      n,
+      (i) => Restaurant(
+        placeId: 'p$i',
+        name: 'R$i',
+        address: 'addr $i',
+        latitude: 0,
+        longitude: 0,
+      ),
+    );
+
+    test('fills columns x rows with unique restaurants when enough', () {
+      final reels = ReelLayout.buildReels(
+        makeRestaurants(12),
+        columns: 3,
+        rows: 4,
+      );
+      expect(reels, hasLength(3));
+      expect(reels.every((r) => r.length == 4), isTrue);
+      // 12 distinct across 3x4.
+      final all = reels.expand((r) => r).map((r) => r.placeId).toSet();
+      expect(all, hasLength(12));
+    });
+
+    test('repeats restaurants to fill when too few (duplicates allowed)', () {
+      final reels = ReelLayout.buildReels(
+        makeRestaurants(2),
+        columns: 3,
+        rows: 2,
+      );
+      // 6 cells filled from 2 restaurants, cycling.
+      final flat = reels.expand((r) => r).map((r) => r.placeId).toList();
+      expect(flat, hasLength(6));
+      expect(flat, ['p0', 'p1', 'p0', 'p1', 'p0', 'p1']);
+    });
+
+    test('returns empty reels for empty input', () {
+      final reels = ReelLayout.buildReels(const [], columns: 2, rows: 3);
+      expect(reels, hasLength(2));
+      expect(reels.every((r) => r.isEmpty), isTrue);
+    });
+
+    test('single column (phone) is the current single-reel case', () {
+      final reels = ReelLayout.buildReels(
+        makeRestaurants(5),
+        columns: 1,
+        rows: 5,
+      );
+      expect(reels, hasLength(1));
+      expect(reels.first.map((r) => r.placeId), ['p0', 'p1', 'p2', 'p3', 'p4']);
+    });
+  });
+}


### PR DESCRIPTION
## What
Step 2 of `docs/SLOT_MACHINE_SPEC.md`. Replaces the single slot-machine reel with a **width-measured multi-reel grid**.

- **Responsive, measured (not device-based):** `LayoutBuilder` → `ReelLayout.columnsForWidth(width)` → 1 reel on phones, 2 on iPad portrait, 3 in landscape. Reels are `Expanded` so they **fill the width with no gutter** — foldables, big phones, and split-screen all covered without device checks.
- **Slot-machine feel kept:** all reels spin and **stop left→right**; one **random winning cell is highlighted** (coral reel border + mustard cell border); the winner is reported via `onSpinComplete` → existing celebration → Detail (unchanged).
- **Duplicates allowed:** cells repeat restaurants when Places returns fewer than `rows×cols`.
- **Phone unchanged:** 1-reel case == prior behavior.

## Tests
- `reel_layout_test` — width→columns math + grid distribution (8 cases).
- `multi_reel_slot_machine_test` — 1/2/3 reels by width, spin reports a valid winner, empty-safe.
- A real bug the tests caught: the reel's `AnimationController` was lazily created and would first-init **inside dispose()** for reels that never spin (ancestor lookup on a dead element → crash). Now created in `initState`.
- analyze + format clean; full suite 294 green.

## Not yet (next spec steps)
- Winner **expand → Hero** into Detail (currently highlight → existing celebration).
- **Calm Mode** reduced-motion toggle.
- Visual sim check pending (doing it now).