### PR TITLE
feat: Spots — saved place + filters, one-tap recall

### DIFF
--- a/lib/blocs/discovery/discovery_notifier.dart
+++ b/lib/blocs/discovery/discovery_notifier.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:randoeats/blocs/discovery/discovery_state.dart';
 import 'package:randoeats/models/models.dart';
+import 'package:randoeats/providers/active_filters_provider.dart';
 import 'package:randoeats/providers/active_region_provider.dart';
 import 'package:randoeats/services/services.dart';
 
@@ -57,6 +58,7 @@ class DiscoveryNotifier extends Notifier<DiscoveryState> {
     if (area == null) return; // failure state already emitted
 
     final settings = _storageService.getSettings();
+    final filters = ref.read(activeFiltersProvider);
     final placesResult = await _placesService.getNearbyRestaurants(
       latitude: area.lat,
       longitude: area.lng,
@@ -64,6 +66,7 @@ class DiscoveryNotifier extends Notifier<DiscoveryState> {
       excludePlaceIds: _storageService.getExcludedPlaceIds(),
       radiusMeters: area.radiusMeters,
       maxResultCount: settings.maxResults,
+      filters: filters,
     );
 
     if (placesResult is PlacesError) {
@@ -78,12 +81,12 @@ class DiscoveryNotifier extends Notifier<DiscoveryState> {
     if (region != null) {
       restaurants = _filterToPolygon(restaurants, region.vertices);
     }
-    restaurants = _applyFilters(restaurants, settings);
+    restaurants = _applyFilters(restaurants, settings, filters);
 
     if (restaurants.isEmpty) {
       state = state.copyWith(
         status: DiscoveryStatus.failure,
-        errorMessage: _emptyMessage(settings, region),
+        errorMessage: _emptyMessage(settings, region, filters),
       );
       return;
     }
@@ -150,9 +153,10 @@ class DiscoveryNotifier extends Notifier<DiscoveryState> {
   List<Restaurant> _applyFilters(
     List<Restaurant> restaurants,
     UserSettings settings,
+    SpotFilters filters,
   ) {
     var result = restaurants;
-    if (settings.includeOpenOnly) {
+    if (settings.includeOpenOnly || filters.openNow) {
       result = result.where((r) => r.isOpen ?? false).toList();
     }
     if (settings.bannedCategories.isNotEmpty) {
@@ -160,8 +164,46 @@ class DiscoveryNotifier extends Notifier<DiscoveryState> {
           .where((r) => !r.types.any(settings.bannedCategories.contains))
           .toList();
     }
+    if (filters.cuisines.isNotEmpty) {
+      result = result
+          .where((r) => r.types.any((t) => filters.cuisines.any(t.contains)))
+          .toList();
+    }
+    if (filters.minRating != null) {
+      result = result
+          .where((r) => (r.rating ?? 0) >= filters.minRating!)
+          .toList();
+    }
+    if (filters.priceLevels.isNotEmpty) {
+      result = result.where((r) {
+        final level = _priceLevelInt(r.priceLevel);
+        return level != null && filters.priceLevels.contains(level);
+      }).toList();
+    }
+    // Atmosphere filters: a null attribute means "unknown" → excluded when the
+    // filter is on (we can't confirm it).
+    if (filters.servesBeer) {
+      result = result.where((r) => r.servesBeer ?? false).toList();
+    }
+    if (filters.outdoorSeating) {
+      result = result.where((r) => r.outdoorSeating ?? false).toList();
+    }
+    if (filters.goodForGroups) {
+      result = result.where((r) => r.goodForGroups ?? false).toList();
+    }
+    if (filters.hasParking) {
+      result = result.where((r) => r.hasParking ?? false).toList();
+    }
     return result;
   }
+
+  int? _priceLevelInt(String? priceLevel) => switch (priceLevel) {
+    r'$' => 1,
+    r'$$' => 2,
+    r'$$$' => 3,
+    r'$$$$' => 4,
+    _ => null,
+  };
 
   /// Sorts unvisited first, then by ascending visit count.
   List<Restaurant> _sortByVisits(List<Restaurant> restaurants) {
@@ -173,7 +215,14 @@ class DiscoveryNotifier extends Notifier<DiscoveryState> {
     });
   }
 
-  String _emptyMessage(UserSettings settings, SavedRegion? region) {
+  String _emptyMessage(
+    UserSettings settings,
+    SavedRegion? region,
+    SpotFilters filters,
+  ) {
+    if (!filters.isEmpty) {
+      return 'No spots match those filters here. Try removing one.';
+    }
     if (region != null) {
       return 'No restaurants found in ${region.name}. '
           'Try a bigger area or different settings.';

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -5,6 +5,7 @@ export 'rating_type.dart';
 export 'recent_pick.dart';
 export 'restaurant.dart';
 export 'saved_region.dart';
+export 'spot_filters.dart';
 export 'user_rating.dart';
 export 'user_settings.dart';
 export 'visited_place.dart';

--- a/lib/models/restaurant.dart
+++ b/lib/models/restaurant.dart
@@ -19,6 +19,10 @@ class Restaurant extends Equatable {
     this.photoReference,
     this.isOpen,
     this.totalRatings,
+    this.servesBeer,
+    this.outdoorSeating,
+    this.goodForGroups,
+    this.hasParking,
   });
 
   /// Creates a [Restaurant] from Places API (New) response.
@@ -40,6 +44,12 @@ class Restaurant extends Equatable {
       photoReference: _extractPhotoName(photos),
       isOpen: openingHours?['openNow'] as bool?,
       totalRatings: json['userRatingCount'] as int?,
+      servesBeer: json['servesBeer'] as bool?,
+      outdoorSeating: json['outdoorSeating'] as bool?,
+      goodForGroups: json['goodForGroups'] as bool?,
+      hasParking: _parseParking(
+        json['parkingOptions'] as Map<String, dynamic>?,
+      ),
     );
   }
 
@@ -87,6 +97,22 @@ class Restaurant extends Equatable {
   @HiveField(10)
   final int? totalRatings;
 
+  /// Serves beer — a Places "atmosphere" field (null = unknown).
+  @HiveField(11)
+  final bool? servesBeer;
+
+  /// Whether the place has outdoor seating / a patio (null = unknown).
+  @HiveField(12)
+  final bool? outdoorSeating;
+
+  /// Whether the place is good for groups (null = unknown).
+  @HiveField(13)
+  final bool? goodForGroups;
+
+  /// Whether the place has any parking option (null = unknown).
+  @HiveField(14)
+  final bool? hasParking;
+
   /// Parses price level from new API enum string format.
   static String? _parsePriceLevelNew(String? level) {
     if (level == null) return null;
@@ -101,6 +127,13 @@ class Restaurant extends Equatable {
       'PRICE_LEVEL_VERY_EXPENSIVE' => r'$$$$',
       _ => null,
     };
+  }
+
+  /// True if any parking option is available (Places `parkingOptions` is a map
+  /// of booleans like freeParkingLot/paidParkingLot/freeStreetParking).
+  static bool? _parseParking(Map<String, dynamic>? parking) {
+    if (parking == null) return null;
+    return parking.values.any((v) => v == true);
   }
 
   /// Extracts photo name from new API photos array.
@@ -145,5 +178,9 @@ class Restaurant extends Equatable {
     photoReference,
     isOpen,
     totalRatings,
+    servesBeer,
+    outdoorSeating,
+    goodForGroups,
+    hasParking,
   ];
 }

--- a/lib/models/restaurant.g.dart
+++ b/lib/models/restaurant.g.dart
@@ -25,13 +25,17 @@ class RestaurantAdapter extends TypeAdapter<Restaurant> {
       photoReference: fields[8] as String?,
       isOpen: fields[9] as bool?,
       totalRatings: fields[10] as int?,
+      servesBeer: fields[11] as bool?,
+      outdoorSeating: fields[12] as bool?,
+      goodForGroups: fields[13] as bool?,
+      hasParking: fields[14] as bool?,
     );
   }
 
   @override
   void write(BinaryWriter writer, Restaurant obj) {
     writer
-      ..writeByte(11)
+      ..writeByte(15)
       ..writeByte(0)
       ..write(obj.placeId)
       ..writeByte(1)
@@ -53,7 +57,15 @@ class RestaurantAdapter extends TypeAdapter<Restaurant> {
       ..writeByte(9)
       ..write(obj.isOpen)
       ..writeByte(10)
-      ..write(obj.totalRatings);
+      ..write(obj.totalRatings)
+      ..writeByte(11)
+      ..write(obj.servesBeer)
+      ..writeByte(12)
+      ..write(obj.outdoorSeating)
+      ..writeByte(13)
+      ..write(obj.goodForGroups)
+      ..writeByte(14)
+      ..write(obj.hasParking);
   }
 
   @override

--- a/lib/models/saved_region.dart
+++ b/lib/models/saved_region.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart';
+import 'package:randoeats/models/spot_filters.dart';
 
 part 'saved_region.g.dart';
 
@@ -18,6 +19,7 @@ class SavedRegion extends Equatable {
     required this.name,
     required this.points,
     required this.createdAt,
+    this.filters,
   });
 
   /// Creates a [SavedRegion] from polygon [vertices] (lat/lng pairs).
@@ -26,6 +28,7 @@ class SavedRegion extends Equatable {
     required String name,
     required List<({double lat, double lng})> vertices,
     required DateTime createdAt,
+    SpotFilters? filters,
   }) {
     final flat = <double>[];
     for (final v in vertices) {
@@ -33,7 +36,13 @@ class SavedRegion extends Equatable {
         ..add(v.lat)
         ..add(v.lng);
     }
-    return SavedRegion(id: id, name: name, points: flat, createdAt: createdAt);
+    return SavedRegion(
+      id: id,
+      name: name,
+      points: flat,
+      createdAt: createdAt,
+      filters: filters,
+    );
   }
 
   /// Unique identifier (e.g. `millisecondsSinceEpoch` as a string).
@@ -52,6 +61,10 @@ class SavedRegion extends Equatable {
   @HiveField(3)
   final DateTime createdAt;
 
+  /// The filters saved with this Spot (the "what"); null = no filters.
+  @HiveField(4)
+  final SpotFilters? filters;
+
   /// The polygon vertices as lat/lng pairs.
   List<({double lat, double lng})> get vertices {
     final result = <({double lat, double lng})>[];
@@ -67,15 +80,17 @@ class SavedRegion extends Equatable {
     String? name,
     List<double>? points,
     DateTime? createdAt,
+    SpotFilters? filters,
   }) {
     return SavedRegion(
       id: id ?? this.id,
       name: name ?? this.name,
       points: points ?? this.points,
       createdAt: createdAt ?? this.createdAt,
+      filters: filters ?? this.filters,
     );
   }
 
   @override
-  List<Object?> get props => [id, name, points, createdAt];
+  List<Object?> get props => [id, name, points, createdAt, filters];
 }

--- a/lib/models/saved_region.g.dart
+++ b/lib/models/saved_region.g.dart
@@ -18,13 +18,14 @@ class SavedRegionAdapter extends TypeAdapter<SavedRegion> {
       name: fields[1] as String,
       points: (fields[2] as List).cast<double>(),
       createdAt: fields[3] as DateTime,
+      filters: fields[4] as SpotFilters?,
     );
   }
 
   @override
   void write(BinaryWriter writer, SavedRegion obj) {
     writer
-      ..writeByte(4)
+      ..writeByte(5)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -32,7 +33,9 @@ class SavedRegionAdapter extends TypeAdapter<SavedRegion> {
       ..writeByte(2)
       ..write(obj.points)
       ..writeByte(3)
-      ..write(obj.createdAt);
+      ..write(obj.createdAt)
+      ..writeByte(4)
+      ..write(obj.filters);
   }
 
   @override

--- a/lib/models/spot_filters.dart
+++ b/lib/models/spot_filters.dart
@@ -1,0 +1,124 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+
+part 'spot_filters.g.dart';
+
+/// The "what" half of a Spot: a tappable set of restaurant filters.
+///
+/// An all-default [SpotFilters] (everything off/empty) means "no filtering" and
+/// reproduces today's behavior. Filters split into cheap ones (cuisine, open,
+/// rating, price) and pricier "atmosphere" ones (beer, patio, groups, parking)
+/// — see [usesAtmosphere].
+@HiveType(typeId: 8)
+class SpotFilters extends Equatable {
+  /// Creates a [SpotFilters]. All fields default to "no filter".
+  const SpotFilters({
+    this.cuisines = const {},
+    this.servesBeer = false,
+    this.outdoorSeating = false,
+    this.goodForGroups = false,
+    this.hasParking = false,
+    this.openNow = false,
+    this.minRating,
+    this.priceLevels = const {},
+  });
+
+  /// Google Places type keywords to match (e.g. `{'mexican', 'hamburger'}`).
+  @HiveField(0)
+  final Set<String> cuisines;
+
+  /// Only places that serve beer (atmosphere field).
+  @HiveField(1)
+  final bool servesBeer;
+
+  /// Only places with outdoor seating / a patio (atmosphere field).
+  @HiveField(2)
+  final bool outdoorSeating;
+
+  /// Only places that are good for groups (atmosphere field).
+  @HiveField(3)
+  final bool goodForGroups;
+
+  /// Only places with parking (atmosphere field).
+  @HiveField(4)
+  final bool hasParking;
+
+  /// Only places open now.
+  @HiveField(5)
+  final bool openNow;
+
+  /// Minimum star rating (e.g. 4.0 = "above average"); null = any.
+  @HiveField(6)
+  final double? minRating;
+
+  /// Allowed price levels (1–4); empty = any.
+  @HiveField(7)
+  final Set<int> priceLevels;
+
+  /// Whether any filter is active (all-default = empty = no filtering).
+  bool get isEmpty =>
+      cuisines.isEmpty &&
+      !servesBeer &&
+      !outdoorSeating &&
+      !goodForGroups &&
+      !hasParking &&
+      !openNow &&
+      minRating == null &&
+      priceLevels.isEmpty;
+
+  /// Whether any atmosphere filter is active (these need the pricier Places
+  /// field mask — request those fields only when this is true).
+  bool get usesAtmosphere =>
+      servesBeer || outdoorSeating || goodForGroups || hasParking;
+
+  /// Count of active filter facets (for a chip-bar badge).
+  int get activeCount {
+    var n = 0;
+    if (cuisines.isNotEmpty) n++;
+    if (servesBeer) n++;
+    if (outdoorSeating) n++;
+    if (goodForGroups) n++;
+    if (hasParking) n++;
+    if (openNow) n++;
+    if (minRating != null) n++;
+    if (priceLevels.isNotEmpty) n++;
+    return n;
+  }
+
+  /// Returns a copy with the given fields replaced. Pass `clearMinRating: true`
+  /// to set [minRating] back to null.
+  SpotFilters copyWith({
+    Set<String>? cuisines,
+    bool? servesBeer,
+    bool? outdoorSeating,
+    bool? goodForGroups,
+    bool? hasParking,
+    bool? openNow,
+    double? minRating,
+    bool clearMinRating = false,
+    Set<int>? priceLevels,
+  }) {
+    return SpotFilters(
+      cuisines: cuisines ?? this.cuisines,
+      servesBeer: servesBeer ?? this.servesBeer,
+      outdoorSeating: outdoorSeating ?? this.outdoorSeating,
+      goodForGroups: goodForGroups ?? this.goodForGroups,
+      hasParking: hasParking ?? this.hasParking,
+      openNow: openNow ?? this.openNow,
+      minRating: clearMinRating ? null : (minRating ?? this.minRating),
+      priceLevels: priceLevels ?? this.priceLevels,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    cuisines,
+    servesBeer,
+    outdoorSeating,
+    goodForGroups,
+    hasParking,
+    openNow,
+    minRating,
+    priceLevels,
+  ];
+}

--- a/lib/models/spot_filters.g.dart
+++ b/lib/models/spot_filters.g.dart
@@ -1,0 +1,59 @@
+// Manual Hive type adapter for SpotFilters
+
+part of 'spot_filters.dart';
+
+/// Hive type adapter for [SpotFilters].
+class SpotFiltersAdapter extends TypeAdapter<SpotFilters> {
+  @override
+  final int typeId = 8;
+
+  @override
+  SpotFilters read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return SpotFilters(
+      cuisines: (fields[0] as List?)?.cast<String>().toSet() ?? const {},
+      servesBeer: fields[1] as bool? ?? false,
+      outdoorSeating: fields[2] as bool? ?? false,
+      goodForGroups: fields[3] as bool? ?? false,
+      hasParking: fields[4] as bool? ?? false,
+      openNow: fields[5] as bool? ?? false,
+      minRating: fields[6] as double?,
+      priceLevels: (fields[7] as List?)?.cast<int>().toSet() ?? const {},
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, SpotFilters obj) {
+    writer
+      ..writeByte(8)
+      ..writeByte(0)
+      ..write(obj.cuisines.toList())
+      ..writeByte(1)
+      ..write(obj.servesBeer)
+      ..writeByte(2)
+      ..write(obj.outdoorSeating)
+      ..writeByte(3)
+      ..write(obj.goodForGroups)
+      ..writeByte(4)
+      ..write(obj.hasParking)
+      ..writeByte(5)
+      ..write(obj.openNow)
+      ..writeByte(6)
+      ..write(obj.minRating)
+      ..writeByte(7)
+      ..write(obj.priceLevels.toList());
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SpotFiltersAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/providers/active_filters_provider.dart
+++ b/lib/providers/active_filters_provider.dart
@@ -1,0 +1,43 @@
+// `set`/`clear` read better at call sites than assignment setters would.
+// ignore_for_file: use_setters_to_change_properties
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:randoeats/models/models.dart';
+
+/// The currently active restaurant filters (the "what" of a search).
+///
+/// Held in memory for the session. The filter chip bar toggles facets here;
+/// selecting a saved Spot replaces the whole set via `set`.
+final activeFiltersProvider =
+    NotifierProvider<ActiveFiltersNotifier, SpotFilters>(
+      ActiveFiltersNotifier.new,
+    );
+
+/// Notifier backing [activeFiltersProvider].
+class ActiveFiltersNotifier extends Notifier<SpotFilters> {
+  @override
+  SpotFilters build() => const SpotFilters();
+
+  /// Replaces the whole filter set (e.g. when a Spot is selected).
+  void set(SpotFilters filters) => state = filters;
+
+  /// Clears all filters.
+  void clear() => state = const SpotFilters();
+
+  /// Applies [change] to the current filters.
+  void update(SpotFilters Function(SpotFilters current) change) =>
+      state = change(state);
+
+  /// Toggles a cuisine code (e.g. 'mexican') on/off.
+  void toggleCuisine(String code) {
+    final next = {...state.cuisines};
+    if (!next.remove(code)) next.add(code);
+    state = state.copyWith(cuisines: next);
+  }
+
+  /// Toggles a price level (1–4) on/off.
+  void togglePriceLevel(int level) {
+    final next = {...state.priceLevels};
+    if (!next.remove(level)) next.add(level);
+    state = state.copyWith(priceLevels: next);
+  }
+}

--- a/lib/screens/region_draw/region_draw_screen.dart
+++ b/lib/screens/region_draw/region_draw_screen.dart
@@ -4,6 +4,7 @@ import 'package:geocoding/geocoding.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:randoeats/config/config.dart';
 import 'package:randoeats/models/models.dart';
+import 'package:randoeats/providers/active_filters_provider.dart';
 import 'package:randoeats/providers/active_region_provider.dart';
 import 'package:randoeats/screens/region_draw/region_draw_controller.dart';
 import 'package:randoeats/services/services.dart';
@@ -109,6 +110,8 @@ class _RegionDrawScreenState extends ConsumerState<RegionDrawScreen> {
       name: name.trim(),
       vertices: vertices,
       createdAt: DateTime.now(),
+      // Bundle the currently-active filters so the Spot recalls where + what.
+      filters: ref.read(activeFiltersProvider),
     );
     await StorageService.instance.saveRegion(region);
     if (!mounted) return;

--- a/lib/screens/results/results_screen.dart
+++ b/lib/screens/results/results_screen.dart
@@ -7,6 +7,7 @@ import 'package:randoeats/app/router.dart';
 import 'package:randoeats/blocs/blocs.dart';
 import 'package:randoeats/config/config.dart';
 import 'package:randoeats/models/models.dart';
+import 'package:randoeats/providers/active_filters_provider.dart';
 import 'package:randoeats/providers/active_region_provider.dart';
 import 'package:randoeats/services/services.dart';
 import 'package:randoeats/widgets/widgets.dart';
@@ -133,12 +134,18 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(discoveryProvider);
-    // Re-run discovery whenever the active scope (Near Me / a region) changes.
-    ref.listen(activeRegionProvider, (previous, next) {
-      if (previous?.id != next?.id) {
-        unawaited(ref.read(discoveryProvider.notifier).start());
-      }
-    });
+    // Re-run discovery whenever the active scope or filters change.
+    ref
+      ..listen(activeRegionProvider, (previous, next) {
+        if (previous?.id != next?.id) {
+          unawaited(ref.read(discoveryProvider.notifier).start());
+        }
+      })
+      ..listen(activeFiltersProvider, (previous, next) {
+        if (previous != next) {
+          unawaited(ref.read(discoveryProvider.notifier).start());
+        }
+      });
     final isSpinning = state.status == DiscoveryStatus.spinning;
     final canRefresh =
         state.status == DiscoveryStatus.success ||
@@ -160,6 +167,8 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
                   onRename: _onRenameRegion,
                   onDelete: _onDeleteRegion,
                 ),
+                // One-tap filters: cuisine + atmosphere + rating/price
+                const FilterChipBar(),
                 // Main content
                 Expanded(
                   child: _buildBody(context, state),

--- a/lib/services/places_service.dart
+++ b/lib/services/places_service.dart
@@ -55,6 +55,27 @@ class PlacesService {
       'places.primaryType,'
       'places.currentOpeningHours';
 
+  /// Extra ("atmosphere") fields, requested only when an atmosphere filter is
+  /// active — these push the request into Google's pricier SKU.
+  static const _atmosphereFields =
+      'places.servesBeer,'
+      'places.outdoorSeating,'
+      'places.goodForGroups,'
+      'places.parkingOptions';
+
+  static String _fieldMaskFor(SpotFilters filters) =>
+      filters.usesAtmosphere ? '$_fieldMask,$_atmosphereFields' : _fieldMask;
+
+  static List<String> _priceLevelEnums(Set<int> levels) {
+    const names = {
+      1: 'PRICE_LEVEL_INEXPENSIVE',
+      2: 'PRICE_LEVEL_MODERATE',
+      3: 'PRICE_LEVEL_EXPENSIVE',
+      4: 'PRICE_LEVEL_VERY_EXPENSIVE',
+    };
+    return levels.map((l) => names[l]).whereType<String>().toList();
+  }
+
   /// Fetches nearby restaurants based on location and optional mood.
   ///
   /// [latitude] and [longitude] specify the search center.
@@ -69,6 +90,7 @@ class PlacesService {
     Set<String> excludePlaceIds = const {},
     int radiusMeters = 5000,
     int maxResultCount = 50,
+    SpotFilters filters = const SpotFilters(),
   }) async {
     if (_apiKey.isEmpty) {
       return const PlacesError(
@@ -78,7 +100,11 @@ class PlacesService {
     }
 
     try {
-      final keyword = _extractKeyword(mood);
+      // Cuisine chips drive the text query when there's no typed mood.
+      final keyword =
+          _extractKeyword(mood) ??
+          (filters.cuisines.isNotEmpty ? filters.cuisines.join(' ') : null);
+      final fieldMask = _fieldMaskFor(filters);
       final List<Restaurant> restaurants;
 
       // Use text search if there's a keyword, otherwise use nearby search
@@ -89,6 +115,8 @@ class PlacesService {
           query: keyword,
           radiusMeters: radiusMeters,
           maxResultCount: maxResultCount,
+          fieldMask: fieldMask,
+          filters: filters,
         );
       } else {
         restaurants = await _nearbySearchRestaurants(
@@ -96,6 +124,7 @@ class PlacesService {
           longitude: longitude,
           radiusMeters: radiusMeters,
           maxResultCount: maxResultCount,
+          fieldMask: fieldMask,
         );
       }
 
@@ -117,30 +146,37 @@ class PlacesService {
     required String query,
     required int radiusMeters,
     required int maxResultCount,
+    required String fieldMask,
+    required SpotFilters filters,
   }) async {
+    final data = <String, dynamic>{
+      'textQuery': '$query restaurant',
+      'includedType': 'restaurant',
+      'locationBias': {
+        'circle': {
+          'center': {'latitude': latitude, 'longitude': longitude},
+          'radius': radiusMeters.toDouble(),
+        },
+      },
+      'pageSize': maxResultCount,
+    };
+    // Cheap server-side filters supported by Text Search.
+    if (filters.openNow) data['openNow'] = true;
+    if (filters.minRating != null) data['minRating'] = filters.minRating;
+    if (filters.priceLevels.isNotEmpty) {
+      data['priceLevels'] = _priceLevelEnums(filters.priceLevels);
+    }
+
     final response = await _client.post<Map<String, dynamic>>(
       '$_baseUrl/places:searchText',
       options: Options(
         headers: {
           'Content-Type': 'application/json',
           'X-Goog-Api-Key': _apiKey,
-          'X-Goog-FieldMask': _fieldMask,
+          'X-Goog-FieldMask': fieldMask,
         },
       ),
-      data: {
-        'textQuery': '$query restaurant',
-        'includedType': 'restaurant',
-        'locationBias': {
-          'circle': {
-            'center': {
-              'latitude': latitude,
-              'longitude': longitude,
-            },
-            'radius': radiusMeters.toDouble(),
-          },
-        },
-        'pageSize': maxResultCount,
-      },
+      data: data,
     );
 
     return _parseResponse(response);
@@ -152,6 +188,7 @@ class PlacesService {
     required double longitude,
     required int radiusMeters,
     required int maxResultCount,
+    required String fieldMask,
   }) async {
     final response = await _client.post<Map<String, dynamic>>(
       '$_baseUrl/places:searchNearby',
@@ -159,7 +196,7 @@ class PlacesService {
         headers: {
           'Content-Type': 'application/json',
           'X-Goog-Api-Key': _apiKey,
-          'X-Goog-FieldMask': _fieldMask,
+          'X-Goog-FieldMask': fieldMask,
         },
       ),
       data: {

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -75,7 +75,8 @@ class StorageService {
       ..registerAdapter(UserSettingsAdapter())
       ..registerAdapter(RestaurantAdapter())
       ..registerAdapter(VisitedPlaceAdapter())
-      ..registerAdapter(SavedRegionAdapter());
+      ..registerAdapter(SavedRegionAdapter())
+      ..registerAdapter(SpotFiltersAdapter());
   }
 
   Future<void> _openBoxes() async {

--- a/lib/widgets/filter_chip_bar.dart
+++ b/lib/widgets/filter_chip_bar.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:randoeats/config/config.dart';
+import 'package:randoeats/providers/active_filters_provider.dart';
+
+/// A cuisine option: a Places type keyword + a label/icon for the chip.
+typedef _Cuisine = ({String code, String label, IconData icon});
+
+const List<_Cuisine> _cuisines = [
+  (code: 'mexican', label: 'Mexican', icon: Icons.local_dining),
+  (code: 'hamburger', label: 'Burgers', icon: Icons.lunch_dining),
+  (code: 'sushi', label: 'Sushi', icon: Icons.set_meal),
+  (code: 'pizza', label: 'Pizza', icon: Icons.local_pizza),
+  (code: 'coffee', label: 'Coffee', icon: Icons.local_cafe),
+];
+
+/// A one-tap, no-typing filter row: cuisine chips + atmosphere/rating/price
+/// toggles. All taps drive [activeFiltersProvider].
+class FilterChipBar extends ConsumerWidget {
+  /// Creates a [FilterChipBar].
+  const FilterChipBar({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filters = ref.watch(activeFiltersProvider);
+    final notifier = ref.read(activeFiltersProvider.notifier);
+
+    return SizedBox(
+      height: 48,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        children: [
+          for (final c in _cuisines)
+            _FacetChip(
+              key: ValueKey('filter_cuisine_${c.code}'),
+              label: c.label,
+              icon: c.icon,
+              selected: filters.cuisines.contains(c.code),
+              onToggle: () => notifier.toggleCuisine(c.code),
+            ),
+          _FacetChip(
+            key: const ValueKey('filter_beer'),
+            label: 'Beer',
+            icon: Icons.sports_bar,
+            selected: filters.servesBeer,
+            onToggle: () =>
+                notifier.update((f) => f.copyWith(servesBeer: !f.servesBeer)),
+          ),
+          _FacetChip(
+            key: const ValueKey('filter_patio'),
+            label: 'Patio',
+            icon: Icons.deck,
+            selected: filters.outdoorSeating,
+            onToggle: () => notifier.update(
+              (f) => f.copyWith(outdoorSeating: !f.outdoorSeating),
+            ),
+          ),
+          _FacetChip(
+            key: const ValueKey('filter_parking'),
+            label: 'Parking',
+            icon: Icons.local_parking,
+            selected: filters.hasParking,
+            onToggle: () =>
+                notifier.update((f) => f.copyWith(hasParking: !f.hasParking)),
+          ),
+          _FacetChip(
+            key: const ValueKey('filter_group'),
+            label: 'Group',
+            icon: Icons.groups,
+            selected: filters.goodForGroups,
+            onToggle: () => notifier.update(
+              (f) => f.copyWith(goodForGroups: !f.goodForGroups),
+            ),
+          ),
+          _FacetChip(
+            key: const ValueKey('filter_open'),
+            label: 'Open',
+            icon: Icons.schedule,
+            selected: filters.openNow,
+            onToggle: () =>
+                notifier.update((f) => f.copyWith(openNow: !f.openNow)),
+          ),
+          _FacetChip(
+            key: const ValueKey('filter_rating'),
+            label: '4.0+',
+            icon: Icons.star,
+            selected: filters.minRating != null,
+            onToggle: () => notifier.update(
+              (f) => f.minRating != null
+                  ? f.copyWith(clearMinRating: true)
+                  : f.copyWith(minRating: 4),
+            ),
+          ),
+          for (final level in const [1, 2, 3])
+            _FacetChip(
+              key: ValueKey('filter_price_$level'),
+              label: r'$' * level,
+              selected: filters.priceLevels.contains(level),
+              onToggle: () => notifier.togglePriceLevel(level),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FacetChip extends StatelessWidget {
+  const _FacetChip({
+    required this.label,
+    required this.selected,
+    required this.onToggle,
+    this.icon,
+    super.key,
+  });
+
+  final String label;
+  final IconData? icon;
+  final bool selected;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final foreground = selected ? GoogieColors.white : GoogieColors.deepTeal;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
+      child: ChoiceChip(
+        avatar: icon == null ? null : Icon(icon, size: 18, color: foreground),
+        label: Text(label),
+        selected: selected,
+        showCheckmark: false,
+        labelStyle: TextStyle(color: foreground, fontWeight: FontWeight.w600),
+        selectedColor: GoogieColors.coral,
+        backgroundColor: GoogieColors.cream,
+        side: const BorderSide(color: GoogieColors.chrome),
+        onSelected: (_) => onToggle(),
+      ),
+    );
+  }
+}

--- a/lib/widgets/region_chip_bar.dart
+++ b/lib/widgets/region_chip_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:randoeats/config/config.dart';
 import 'package:randoeats/models/models.dart';
+import 'package:randoeats/providers/active_filters_provider.dart';
 import 'package:randoeats/providers/active_region_provider.dart';
 
 /// A horizontal, one-tap scope picker shown on the results screen.
@@ -56,7 +57,13 @@ class RegionChipBar extends ConsumerWidget {
               label: region.name,
               icon: Icons.place,
               selected: active?.id == region.id,
-              onTap: () => notifier.select(region),
+              // Selecting a Spot restores both its area and its filters.
+              onTap: () {
+                notifier.select(region);
+                ref
+                    .read(activeFiltersProvider.notifier)
+                    .set(region.filters ?? const SpotFilters());
+              },
               onLongPress: () => _showRegionMenu(context, region),
             ),
           _ScopeChip(

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -1,6 +1,7 @@
 /// Widgets for rand-o-eats.
 library;
 
+export 'filter_chip_bar.dart';
 export 'multi_reel_slot_machine.dart';
 export 'rando_eats_button.dart';
 export 'reel_layout.dart';

--- a/test/blocs/discovery/discovery_notifier_test.dart
+++ b/test/blocs/discovery/discovery_notifier_test.dart
@@ -4,6 +4,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:randoeats/blocs/blocs.dart';
 import 'package:randoeats/models/models.dart';
+import 'package:randoeats/providers/active_filters_provider.dart';
 import 'package:randoeats/providers/active_region_provider.dart';
 import 'package:randoeats/services/services.dart';
 
@@ -58,6 +59,10 @@ void main() {
     late MockLocationService mockLocationService;
     late MockStorageService mockStorageService;
     late Position testPosition;
+
+    setUpAll(() {
+      registerFallbackValue(const SpotFilters());
+    });
 
     setUp(() {
       mockPlacesService = MockPlacesService();
@@ -516,6 +521,115 @@ void main() {
         final state = container.read(discoveryProvider);
         expect(state.status, DiscoveryStatus.failure);
         expect(state.errorMessage, contains('Orange Circle'));
+      });
+    });
+
+    group('filters', () {
+      const beerMex = Restaurant(
+        placeId: 'beer_mex',
+        name: 'Beer Mex',
+        address: 'a',
+        latitude: 34,
+        longitude: -118,
+        rating: 4.6,
+        priceLevel: r'$',
+        isOpen: true,
+        types: ['restaurant', 'mexican_restaurant'],
+        servesBeer: true,
+        outdoorSeating: true,
+        goodForGroups: true,
+        hasParking: true,
+      );
+      const sushiNoBeer = Restaurant(
+        placeId: 'sushi',
+        name: 'Sushi',
+        address: 'b',
+        latitude: 34,
+        longitude: -118,
+        rating: 3.9,
+        priceLevel: r'$$$',
+        isOpen: true,
+        types: ['restaurant', 'sushi_restaurant'],
+        servesBeer: false,
+        outdoorSeating: false,
+      );
+      const burgerBeer = Restaurant(
+        placeId: 'burger',
+        name: 'Burger',
+        address: 'c',
+        latitude: 34,
+        longitude: -118,
+        rating: 4.2,
+        priceLevel: r'$$',
+        isOpen: true,
+        types: ['restaurant', 'hamburger_restaurant'],
+        servesBeer: true,
+        outdoorSeating: false,
+      );
+      const all = [beerMex, sushiNoBeer, burgerBeer];
+
+      void stubPlaces() {
+        when(
+          () => mockPlacesService.getNearbyRestaurants(
+            latitude: any(named: 'latitude'),
+            longitude: any(named: 'longitude'),
+            mood: any(named: 'mood'),
+            excludePlaceIds: any(named: 'excludePlaceIds'),
+            radiusMeters: any(named: 'radiusMeters'),
+            maxResultCount: any(named: 'maxResultCount'),
+            filters: any(named: 'filters'),
+          ),
+        ).thenAnswer((_) async => const PlacesSuccess(all));
+        when(
+          () => mockLocationService.getCurrentLocation(),
+        ).thenAnswer((_) async => LocationSuccess(testPosition));
+      }
+
+      Future<Set<String>> runWith(SpotFilters filters) async {
+        stubPlaces();
+        final container = buildContainer();
+        container.read(activeFiltersProvider.notifier).set(filters);
+        await container.read(discoveryProvider.notifier).start();
+        return container
+            .read(discoveryProvider)
+            .restaurants
+            .map((r) => r.placeId)
+            .toSet();
+      }
+
+      test('cuisine keeps only matching types', () async {
+        expect(await runWith(const SpotFilters(cuisines: {'mexican'})), {
+          'beer_mex',
+        });
+      });
+
+      test('minRating keeps only high-rated', () async {
+        expect(await runWith(const SpotFilters(minRating: 4.5)), {'beer_mex'});
+      });
+
+      test('servesBeer keeps only beer places', () async {
+        expect(await runWith(const SpotFilters(servesBeer: true)), {
+          'beer_mex',
+          'burger',
+        });
+      });
+
+      test('priceLevels keeps only matching price', () async {
+        final ids = await runWith(const SpotFilters(priceLevels: {1}));
+        expect(ids, {'beer_mex'});
+      });
+
+      test('outdoorSeating excludes unknown/false', () async {
+        expect(await runWith(const SpotFilters(outdoorSeating: true)), {
+          'beer_mex',
+        });
+      });
+
+      test('combined filters intersect', () async {
+        final ids = await runWith(
+          const SpotFilters(servesBeer: true, minRating: 4.5),
+        );
+        expect(ids, {'beer_mex'}); // beer AND >=4.5
       });
     });
 

--- a/test/models/restaurant_test.dart
+++ b/test/models/restaurant_test.dart
@@ -48,6 +48,10 @@ void main() {
         'photo_ref_123',
         true,
         100,
+        null, // servesBeer
+        null, // outdoorSeating
+        null, // goodForGroups
+        null, // hasParking
       ]);
     });
 

--- a/test/models/saved_region_test.dart
+++ b/test/models/saved_region_test.dart
@@ -34,6 +34,7 @@ void main() {
         'Orange Circle',
         region.points,
         createdAt,
+        null, // filters
       ]);
     });
 
@@ -106,6 +107,9 @@ void main() {
         if (!Hive.isAdapterRegistered(7)) {
           Hive.registerAdapter(SavedRegionAdapter());
         }
+        if (!Hive.isAdapterRegistered(8)) {
+          Hive.registerAdapter(SpotFiltersAdapter());
+        }
       });
 
       tearDown(() async {
@@ -125,6 +129,33 @@ void main() {
 
         final reopened = await Hive.openBox<SavedRegion>('regions_roundtrip');
         expect(reopened.get('r1'), equals(region));
+      });
+
+      test('round-trips a Spot with filters', () async {
+        final spot = buildSquare().copyWith(
+          filters: const SpotFilters(
+            cuisines: {'tacos'},
+            servesBeer: true,
+            minRating: 4,
+          ),
+        );
+        final box = await Hive.openBox<SavedRegion>('spots_roundtrip');
+        await box.put(spot.id, spot);
+        await box.close();
+
+        final reopened = await Hive.openBox<SavedRegion>('spots_roundtrip');
+        final read = reopened.get('r1');
+        expect(read, equals(spot));
+        expect(read!.filters?.servesBeer, isTrue);
+        expect(read.filters?.cuisines, {'tacos'});
+      });
+
+      test('null filters round-trips (backward compatible)', () async {
+        final box = await Hive.openBox<SavedRegion>('nofilters');
+        await box.put('r1', buildSquare()); // no filters
+        await box.close();
+        final reopened = await Hive.openBox<SavedRegion>('nofilters');
+        expect(reopened.get('r1')!.filters, isNull);
       });
     });
   });

--- a/test/models/spot_filters_test.dart
+++ b/test/models/spot_filters_test.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:randoeats/models/models.dart';
+
+void main() {
+  group('SpotFilters', () {
+    test('defaults to empty / no filtering', () {
+      const f = SpotFilters();
+      expect(f.isEmpty, isTrue);
+      expect(f.usesAtmosphere, isFalse);
+      expect(f.activeCount, 0);
+    });
+
+    test('activeCount counts each active facet', () {
+      const f = SpotFilters(
+        cuisines: {'mexican'},
+        servesBeer: true,
+        openNow: true,
+        minRating: 4,
+        priceLevels: {1, 2},
+      );
+      expect(f.isEmpty, isFalse);
+      expect(f.activeCount, 5); // cuisines, beer, open, rating, price
+    });
+
+    test('usesAtmosphere is true only for atmosphere facets', () {
+      expect(const SpotFilters(openNow: true).usesAtmosphere, isFalse);
+      expect(const SpotFilters(minRating: 4).usesAtmosphere, isFalse);
+      expect(const SpotFilters(servesBeer: true).usesAtmosphere, isTrue);
+      expect(const SpotFilters(outdoorSeating: true).usesAtmosphere, isTrue);
+      expect(const SpotFilters(goodForGroups: true).usesAtmosphere, isTrue);
+      expect(const SpotFilters(hasParking: true).usesAtmosphere, isTrue);
+    });
+
+    test('copyWith replaces fields; clearMinRating nulls it', () {
+      const f = SpotFilters(minRating: 4, servesBeer: true);
+      expect(f.copyWith(servesBeer: false).servesBeer, isFalse);
+      expect(f.copyWith(minRating: 4.5).minRating, 4.5);
+      expect(f.copyWith(clearMinRating: true).minRating, isNull);
+      // unchanged fields persist
+      expect(f.copyWith(openNow: true).servesBeer, isTrue);
+    });
+
+    test('supports value equality', () {
+      expect(
+        const SpotFilters(cuisines: {'a'}, servesBeer: true),
+        const SpotFilters(cuisines: {'a'}, servesBeer: true),
+      );
+      expect(
+        const SpotFilters(cuisines: {'a'}),
+        isNot(const SpotFilters(cuisines: {'b'})),
+      );
+    });
+
+    group('SpotFiltersAdapter', () {
+      late Directory tempDir;
+
+      setUp(() async {
+        tempDir = await Directory.systemTemp.createTemp('spot_filters_test');
+        Hive.init(tempDir.path);
+        if (!Hive.isAdapterRegistered(8)) {
+          Hive.registerAdapter(SpotFiltersAdapter());
+        }
+      });
+
+      tearDown(() async {
+        await Hive.deleteFromDisk();
+        await tempDir.delete(recursive: true);
+      });
+
+      test('round-trips a populated filter set', () async {
+        const filters = SpotFilters(
+          cuisines: {'mexican', 'hamburger'},
+          servesBeer: true,
+          outdoorSeating: true,
+          goodForGroups: true,
+          hasParking: true,
+          openNow: true,
+          minRating: 4.2,
+          priceLevels: {1, 2, 3},
+        );
+        final box = await Hive.openBox<SpotFilters>('f');
+        await box.put('k', filters);
+        await box.close();
+
+        final reopened = await Hive.openBox<SpotFilters>('f');
+        expect(reopened.get('k'), filters);
+      });
+
+      test('round-trips defaults', () async {
+        final box = await Hive.openBox<SpotFilters>('f');
+        await box.put('k', const SpotFilters());
+        await box.close();
+        final reopened = await Hive.openBox<SpotFilters>('f');
+        expect(reopened.get('k'), const SpotFilters());
+      });
+    });
+  });
+}

--- a/test/providers/active_filters_provider_test.dart
+++ b/test/providers/active_filters_provider_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:randoeats/models/models.dart';
+import 'package:randoeats/providers/active_filters_provider.dart';
+
+void main() {
+  group('activeFiltersProvider', () {
+    late ProviderContainer container;
+
+    setUp(() => container = ProviderContainer());
+    tearDown(() => container.dispose());
+
+    SpotFilters read() => container.read(activeFiltersProvider);
+    ActiveFiltersNotifier notifier() =>
+        container.read(activeFiltersProvider.notifier);
+
+    test('defaults to empty', () {
+      expect(read().isEmpty, isTrue);
+    });
+
+    test('set replaces the whole filter set', () {
+      notifier().set(const SpotFilters(servesBeer: true, minRating: 4));
+      expect(read().servesBeer, isTrue);
+      expect(read().minRating, 4);
+    });
+
+    test('clear resets to empty', () {
+      notifier()
+        ..set(const SpotFilters(openNow: true))
+        ..clear();
+      expect(read().isEmpty, isTrue);
+    });
+
+    test('toggleCuisine adds then removes', () {
+      notifier().toggleCuisine('tacos');
+      expect(read().cuisines, {'tacos'});
+      notifier().toggleCuisine('tacos');
+      expect(read().cuisines, isEmpty);
+    });
+
+    test('togglePriceLevel adds then removes', () {
+      notifier().togglePriceLevel(2);
+      expect(read().priceLevels, {2});
+      notifier().togglePriceLevel(2);
+      expect(read().priceLevels, isEmpty);
+    });
+
+    test('update applies a copyWith change', () {
+      notifier().update((f) => f.copyWith(minRating: 4));
+      expect(read().minRating, 4);
+    });
+  });
+}

--- a/test/widgets/filter_chip_bar_test.dart
+++ b/test/widgets/filter_chip_bar_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:randoeats/providers/active_filters_provider.dart';
+import 'package:randoeats/widgets/filter_chip_bar.dart';
+
+void main() {
+  group('FilterChipBar', () {
+    Future<ProviderContainer> pump(WidgetTester tester) async {
+      // Wide surface so every chip is on-screen and hittable.
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.physicalSize = const Size(2200, 400);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: Scaffold(body: FilterChipBar())),
+        ),
+      );
+      return container;
+    }
+
+    testWidgets('renders cuisine + facet chips', (tester) async {
+      await pump(tester);
+      expect(find.text('Mexican'), findsOneWidget);
+      expect(find.text('Beer'), findsOneWidget);
+      expect(find.text('Patio'), findsOneWidget);
+      expect(find.text('4.0+'), findsOneWidget);
+    });
+
+    testWidgets('tapping Beer toggles servesBeer', (tester) async {
+      final container = await pump(tester);
+      await tester.tap(find.byKey(const ValueKey('filter_beer')));
+      await tester.pump();
+      expect(container.read(activeFiltersProvider).servesBeer, isTrue);
+      await tester.tap(find.byKey(const ValueKey('filter_beer')));
+      await tester.pump();
+      expect(container.read(activeFiltersProvider).servesBeer, isFalse);
+    });
+
+    testWidgets('tapping Mexican toggles the cuisine', (tester) async {
+      final container = await pump(tester);
+      await tester.tap(find.byKey(const ValueKey('filter_cuisine_mexican')));
+      await tester.pump();
+      expect(container.read(activeFiltersProvider).cuisines, {'mexican'});
+    });
+
+    testWidgets('tapping 4.0+ sets then clears minRating', (tester) async {
+      final container = await pump(tester);
+      await tester.tap(find.byKey(const ValueKey('filter_rating')));
+      await tester.pump();
+      expect(container.read(activeFiltersProvider).minRating, 4.0);
+      await tester.tap(find.byKey(const ValueKey('filter_rating')));
+      await tester.pump();
+      expect(container.read(activeFiltersProvider).minRating, isNull);
+    });
+
+    testWidgets('tapping a price chip toggles the level', (tester) async {
+      final container = await pump(tester);
+      await tester.tap(find.byKey(const ValueKey('filter_price_2')));
+      await tester.pump();
+      expect(container.read(activeFiltersProvider).priceLevels, {2});
+    });
+  });
+}

--- a/test/widgets/region_chip_bar_test.dart
+++ b/test/widgets/region_chip_bar_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:randoeats/models/models.dart';
+import 'package:randoeats/providers/active_filters_provider.dart';
 import 'package:randoeats/providers/active_region_provider.dart';
 import 'package:randoeats/widgets/region_chip_bar.dart';
 
@@ -66,6 +67,36 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('region_chip_r1')));
       await tester.pump();
       expect(container.read(activeRegionProvider)?.id, 'r1');
+    });
+
+    testWidgets('selecting a Spot restores its area AND filters', (
+      tester,
+    ) async {
+      final spot = region('s1', 'Beer Spot').copyWith(
+        filters: const SpotFilters(servesBeer: true, minRating: 4),
+      );
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: Scaffold(
+              body: RegionChipBar(
+                regions: [spot],
+                onCreate: () {},
+                onRename: (_) {},
+                onDelete: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byKey(const ValueKey('region_chip_s1')));
+      await tester.pump();
+      expect(container.read(activeRegionProvider)?.id, 's1');
+      expect(container.read(activeFiltersProvider).servesBeer, isTrue);
+      expect(container.read(activeFiltersProvider).minRating, 4);
     });
 
     testWidgets('tapping Near Me clears the active region', (tester) async {


### PR DESCRIPTION
Implements `docs/SPOTS_SPEC.md` — a **Spot** = where (region) + what (filters) + name, recalled in one tap. No chat, no LLM, no typing.

## What's in it
**Data**
- `SpotFilters` (Hive typeId 8): cuisines, beer/patio/groups/parking, openNow, minRating, priceLevels (+ isEmpty/usesAtmosphere/activeCount/copyWith).
- `SavedRegion` gains an optional `filters` field (a region becomes a Spot) — Hive-backward-compatible.
- `Restaurant` gains atmosphere fields (servesBeer/outdoorSeating/goodForGroups/hasParking) parsed from Places (New).

**Behavior**
- `activeFiltersProvider` (session filter state).
- `PlacesService`: dynamic field mask (atmosphere fields **only when used** → cost control), cuisine drives the text query, openNow/minRating/priceLevels passed to Text Search.
- `DiscoveryNotifier`: reads active filters, threads to Places, and **enforces all filters client-side** (cuisine/rating/price/atmosphere; unknown atmosphere attr excluded when that filter is on).

**UI**
- `FilterChipBar`: one-tap cuisine + atmosphere + rating/price chips on the results screen; discovery re-runs on change. ValueKeys on every chip.
- Spot save/recall: drawing a new area bundles current filters; selecting a region chip restores its area **and** filters.

## Tests
SpotFilters (model + Hive round-trip), SavedRegion-with-filters round-trip, Restaurant atmosphere props, activeFiltersProvider, discovery filtering (each facet narrows results + combined), FilterChipBar widget, Spot-restores-filters. analyze + format clean; full suite **321 green**.

## Deferred (follow-ups, noted in spec)
- Auto-namer tuning (neighborhood→street→city) + shared `place_namer`.
- A "save current ad-hoc filters to a Spot" ⭐ affordance from results.
- Maestro flow updates.