### PR TITLE
feat: Hero flight from winning cell into detail screen

### DIFF
--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -6,6 +6,7 @@ import 'package:randoeats/blocs/blocs.dart';
 import 'package:randoeats/config/config.dart';
 import 'package:randoeats/models/models.dart';
 import 'package:randoeats/services/services.dart';
+import 'package:randoeats/widgets/widgets.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// Screen displaying restaurant details with navigation and rating options.
@@ -52,23 +53,27 @@ class DetailScreen extends ConsumerWidget {
       maxWidth: 800,
     );
 
-    return Container(
-      height: 200,
-      decoration: BoxDecoration(
-        color: GoogieColors.turquoise.withValues(alpha: 0.2),
+    return Hero(
+      tag: restaurantPhotoHeroTag(restaurant.placeId),
+      child: Container(
+        height: 200,
+        decoration: BoxDecoration(
+          color: GoogieColors.turquoise.withValues(alpha: 0.2),
+        ),
+        child: photoUrl != null
+            ? Image.network(
+                photoUrl,
+                fit: BoxFit.cover,
+                width: double.infinity,
+                errorBuilder: (_, error, stackTrace) =>
+                    _buildPhotoPlaceholder(),
+                loadingBuilder: (context, child, loadingProgress) {
+                  if (loadingProgress == null) return child;
+                  return _buildPhotoPlaceholder(isLoading: true);
+                },
+              )
+            : _buildPhotoPlaceholder(),
       ),
-      child: photoUrl != null
-          ? Image.network(
-              photoUrl,
-              fit: BoxFit.cover,
-              width: double.infinity,
-              errorBuilder: (_, error, stackTrace) => _buildPhotoPlaceholder(),
-              loadingBuilder: (context, child, loadingProgress) {
-                if (loadingProgress == null) return child;
-                return _buildPhotoPlaceholder(isLoading: true);
-              },
-            )
-          : _buildPhotoPlaceholder(),
     );
   }
 

--- a/lib/widgets/multi_reel_slot_machine.dart
+++ b/lib/widgets/multi_reel_slot_machine.dart
@@ -337,6 +337,11 @@ class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
                   key: ValueKey('reel_cell_${restaurant.placeId}_$index'),
                   restaurant: restaurant,
                   index: index,
+                  // Only the unique winning cell anchors the Hero flight into
+                  // the detail screen; repeated cells leave it null.
+                  heroTag: isWinnerCell
+                      ? restaurantPhotoHeroTag(restaurant.placeId)
+                      : null,
                   onTap: widget.spinning
                       ? () {}
                       : () => widget.onCardTap(restaurant),

--- a/lib/widgets/restaurant_card.dart
+++ b/lib/widgets/restaurant_card.dart
@@ -3,6 +3,10 @@ import 'package:randoeats/config/config.dart';
 import 'package:randoeats/models/models.dart';
 import 'package:randoeats/services/services.dart';
 
+/// Hero tag for a restaurant's photo, shared between the winning slot-machine
+/// cell and the detail screen header so the photo flies between them.
+String restaurantPhotoHeroTag(String placeId) => 'restaurant_photo_$placeId';
+
 /// A card displaying restaurant information in Googie style.
 class RestaurantCard extends StatelessWidget {
   /// Creates a [RestaurantCard].
@@ -10,6 +14,7 @@ class RestaurantCard extends StatelessWidget {
     required this.restaurant,
     required this.onTap,
     this.index = 0,
+    this.heroTag,
     super.key,
   });
 
@@ -21,6 +26,11 @@ class RestaurantCard extends StatelessWidget {
 
   /// Index in the list (used for animation stagger).
   final int index;
+
+  /// Optional Hero tag for the photo. Set only for a unique card (e.g. the
+  /// winning reel cell) — repeated cells must leave this null to avoid
+  /// duplicate Hero tags on the same route.
+  final String? heroTag;
 
   @override
   Widget build(BuildContext context) {
@@ -69,7 +79,7 @@ class RestaurantCard extends StatelessWidget {
       restaurant.photoReference,
     );
 
-    return ClipRRect(
+    final photo = ClipRRect(
       borderRadius: const BorderRadius.vertical(top: Radius.circular(10)),
       child: Container(
         height: 80,
@@ -90,6 +100,9 @@ class RestaurantCard extends StatelessWidget {
             : _buildPlaceholder(),
       ),
     );
+
+    if (heroTag == null) return photo;
+    return Hero(tag: heroTag!, child: photo);
   }
 
   Widget _buildPlaceholder({bool isLoading = false}) {

--- a/test/widgets/restaurant_card_test.dart
+++ b/test/widgets/restaurant_card_test.dart
@@ -191,6 +191,30 @@ void main() {
       expect(find.byType(RestaurantCard), findsOneWidget);
     });
 
+    testWidgets('wraps photo in a Hero when heroTag is set', (tester) async {
+      await tester.pumpApp(
+        RestaurantCard(
+          restaurant: _testRestaurant,
+          onTap: () {},
+          heroTag: restaurantPhotoHeroTag(_testRestaurant.placeId),
+        ),
+      );
+
+      final hero = tester.widget<Hero>(find.byType(Hero));
+      expect(hero.tag, 'restaurant_photo_place_1');
+    });
+
+    testWidgets('has no Hero when heroTag is null', (tester) async {
+      await tester.pumpApp(
+        RestaurantCard(
+          restaurant: _testRestaurant,
+          onTap: () {},
+        ),
+      );
+
+      expect(find.byType(Hero), findsNothing);
+    });
+
     testWidgets('renders rating without totalRatings', (tester) async {
       const restaurantNoCount = Restaurant(
         placeId: 'p1',


### PR DESCRIPTION
Completes the slot-machine winner reveal: **spin → expand → fly into detail**.

The winning reel cell's photo now performs a Hero transition into the detail-screen header, so the chosen restaurant visibly carries through to its detail page.

## What's in it
- `restaurantPhotoHeroTag(placeId)` — one shared tag helper so source and destination always match.
- `RestaurantCard` gains an optional `heroTag`; **only the unique winning cell** sets it. Repeated reel cells leave it null to avoid duplicate Hero tags on the same route.
- Detail header photo wrapped in the matching `Hero`. Direct-tap navigation (non-winner) simply has a destination-only Hero — no flight, renders normally.

## Tests
- RestaurantCard wraps its photo in a `Hero` with the shared tag when set; no `Hero` when null.
- Full suite **325 green**, analyze `--fatal-infos --fatal-warnings` clean, format clean.

## Notes
This is the last deferred piece of the multi-reel slot machine (steps 3–5 now complete). Separately still tracked: the iPad/accessibility-pass infinite-width Detail bug.