### PR TITLE
feat: save current filters as a Spot (incl. GPS spots)

### DIFF
--- a/lib/models/saved_region.dart
+++ b/lib/models/saved_region.dart
@@ -65,6 +65,12 @@ class SavedRegion extends Equatable {
   @HiveField(4)
   final SpotFilters? filters;
 
+  /// Whether this Spot has a usable drawn area (a polygon of ≥3 vertices).
+  ///
+  /// An area-less Spot represents "Near Me" — discovery falls back to the
+  /// device's GPS location and applies only the saved [filters].
+  bool get hasArea => vertices.length >= 3;
+
   /// The polygon vertices as lat/lng pairs.
   List<({double lat, double lng})> get vertices {
     final result = <({double lat, double lng})>[];

--- a/lib/models/spot_filters.dart
+++ b/lib/models/spot_filters.dart
@@ -71,6 +71,35 @@ class SpotFilters extends Equatable {
   bool get usesAtmosphere =>
       servesBeer || outdoorSeating || goodForGroups || hasParking;
 
+  /// Display labels for known cuisine codes; unknown codes are title-cased.
+  static const _cuisineLabels = <String, String>{
+    'mexican': 'Mexican',
+    'hamburger': 'Burgers',
+    'sushi': 'Sushi',
+    'pizza': 'Pizza',
+    'coffee': 'Coffee',
+  };
+
+  /// A short, human-friendly summary of the active filters, e.g.
+  /// `Mexican · Beer · 4.0+`. Empty string when no filters are active.
+  String get summaryLabel {
+    final sortedCuisines = cuisines.toList()..sort();
+    final sortedPrices = priceLevels.toList()..sort();
+    final parts = <String>[
+      for (final c in sortedCuisines)
+        _cuisineLabels[c] ??
+            (c.isEmpty ? c : '${c[0].toUpperCase()}${c.substring(1)}'),
+      if (servesBeer) 'Beer',
+      if (outdoorSeating) 'Patio',
+      if (hasParking) 'Parking',
+      if (goodForGroups) 'Group',
+      if (openNow) 'Open',
+      if (minRating != null) '${minRating!.toStringAsFixed(1)}+',
+      for (final level in sortedPrices) r'$' * level,
+    ];
+    return parts.join(' · ');
+  }
+
   /// Count of active filter facets (for a chip-bar badge).
   int get activeCount {
     var n = 0;

--- a/lib/screens/results/results_screen.dart
+++ b/lib/screens/results/results_screen.dart
@@ -92,6 +92,76 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
     _loadRegions();
   }
 
+  /// Saves the current filters (and the active area, if any) as a named Spot.
+  ///
+  /// On "Near Me" this creates an area-less (GPS) Spot — recalling it searches
+  /// the user's location with these filters. With an area active, the new Spot
+  /// reuses that area's polygon plus the current filters.
+  Future<void> _onSaveSpot() async {
+    final filters = ref.read(activeFiltersProvider);
+    if (filters.isEmpty) return;
+
+    final activeRegion = ref.read(activeRegionProvider);
+    final hasArea = activeRegion != null && activeRegion.hasArea;
+    final areaName = hasArea ? activeRegion.name : null;
+    final summary = filters.summaryLabel;
+    final suggestion = areaName == null ? summary : '$areaName — $summary';
+
+    final controller = TextEditingController(text: suggestion);
+    final name = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Row(
+          children: [
+            Icon(Icons.star, color: GoogieColors.mustard),
+            SizedBox(width: 8),
+            Text('Save Spot'),
+          ],
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              key: const ValueKey('spot_name_field'),
+              controller: controller,
+              autofocus: true,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            const SizedBox(height: 16),
+            Text('Area: ${areaName ?? 'Near Me (GPS)'}'),
+            const SizedBox(height: 4),
+            Text('Filters: $summary'),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            key: const ValueKey('spot_save_confirm'),
+            onPressed: () => Navigator.pop(dialogContext, controller.text),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    if (name == null || name.trim().isEmpty) return;
+
+    final now = DateTime.now();
+    final spot = SavedRegion(
+      id: now.millisecondsSinceEpoch.toString(),
+      name: name.trim(),
+      points: hasArea ? activeRegion.points : const <double>[],
+      createdAt: now,
+      filters: filters,
+    );
+    await StorageService.instance.saveRegion(spot);
+    ref.read(activeRegionProvider.notifier).select(spot);
+    _loadRegions();
+  }
+
   void _startSpin() {
     ref.read(discoveryProvider.notifier).startSpin();
     _slotMachineKey.currentState?.spin();
@@ -168,7 +238,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
                   onDelete: _onDeleteRegion,
                 ),
                 // One-tap filters: cuisine + atmosphere + rating/price
-                const FilterChipBar(),
+                FilterChipBar(onSaveSpot: _onSaveSpot),
                 // Main content
                 Expanded(
                   child: _buildBody(context, state),

--- a/lib/widgets/filter_chip_bar.dart
+++ b/lib/widgets/filter_chip_bar.dart
@@ -18,7 +18,11 @@ const List<_Cuisine> _cuisines = [
 /// toggles. All taps drive [activeFiltersProvider].
 class FilterChipBar extends ConsumerWidget {
   /// Creates a [FilterChipBar].
-  const FilterChipBar({super.key});
+  const FilterChipBar({this.onSaveSpot, super.key});
+
+  /// Called when the user taps the trailing "save as Spot" star. The star is
+  /// shown only when this is non-null and at least one filter is active.
+  final VoidCallback? onSaveSpot;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -98,6 +102,27 @@ class FilterChipBar extends ConsumerWidget {
               label: r'$' * level,
               selected: filters.priceLevels.contains(level),
               onToggle: () => notifier.togglePriceLevel(level),
+            ),
+          // Trailing: save the current ad-hoc filters as a named Spot.
+          if (onSaveSpot != null && !filters.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
+              child: ActionChip(
+                key: const ValueKey('filter_save_spot'),
+                avatar: const Icon(
+                  Icons.star,
+                  size: 18,
+                  color: GoogieColors.deepTeal,
+                ),
+                label: const Text('Save Spot'),
+                labelStyle: const TextStyle(
+                  color: GoogieColors.deepTeal,
+                  fontWeight: FontWeight.w600,
+                ),
+                backgroundColor: GoogieColors.mustard,
+                side: const BorderSide(color: GoogieColors.chrome),
+                onPressed: onSaveSpot,
+              ),
             ),
         ],
       ),

--- a/test/models/saved_region_test.dart
+++ b/test/models/saved_region_test.dart
@@ -19,6 +19,19 @@ void main() {
       expect(buildSquare(), equals(buildSquare()));
     });
 
+    test('hasArea is true for a polygon, false for an area-less Spot', () {
+      expect(buildSquare().hasArea, isTrue);
+      final gpsSpot = SavedRegion(
+        id: 'g1',
+        name: 'Quick Tacos',
+        points: const [],
+        createdAt: createdAt,
+      );
+      expect(gpsSpot.hasArea, isFalse);
+      // Two vertices (4 doubles) is still not a polygon.
+      expect(gpsSpot.copyWith(points: const [0, 0, 1, 1]).hasArea, isFalse);
+    });
+
     test('differs when any field differs', () {
       expect(buildSquare(), isNot(equals(buildSquare().copyWith(id: 'r2'))));
       expect(

--- a/test/models/spot_filters_test.dart
+++ b/test/models/spot_filters_test.dart
@@ -25,6 +25,22 @@ void main() {
       expect(f.activeCount, 5); // cuisines, beer, open, rating, price
     });
 
+    test('summaryLabel renders a short, ordered summary', () {
+      expect(const SpotFilters().summaryLabel, '');
+      const f = SpotFilters(
+        cuisines: {'mexican'},
+        servesBeer: true,
+        minRating: 4,
+        priceLevels: {1, 2},
+      );
+      expect(f.summaryLabel, r'Mexican · Beer · 4.0+ · $ · $$');
+      // Known cuisine code maps to a friendly label.
+      expect(
+        const SpotFilters(cuisines: {'hamburger'}).summaryLabel,
+        'Burgers',
+      );
+    });
+
     test('usesAtmosphere is true only for atmosphere facets', () {
       expect(const SpotFilters(openNow: true).usesAtmosphere, isFalse);
       expect(const SpotFilters(minRating: 4).usesAtmosphere, isFalse);

--- a/test/widgets/filter_chip_bar_test.dart
+++ b/test/widgets/filter_chip_bar_test.dart
@@ -6,7 +6,10 @@ import 'package:randoeats/widgets/filter_chip_bar.dart';
 
 void main() {
   group('FilterChipBar', () {
-    Future<ProviderContainer> pump(WidgetTester tester) async {
+    Future<ProviderContainer> pump(
+      WidgetTester tester, {
+      VoidCallback? onSaveSpot,
+    }) async {
       // Wide surface so every chip is on-screen and hittable.
       tester.view.devicePixelRatio = 1.0;
       tester.view.physicalSize = const Size(2200, 400);
@@ -17,7 +20,9 @@ void main() {
       await tester.pumpWidget(
         UncontrolledProviderScope(
           container: container,
-          child: const MaterialApp(home: Scaffold(body: FilterChipBar())),
+          child: MaterialApp(
+            home: Scaffold(body: FilterChipBar(onSaveSpot: onSaveSpot)),
+          ),
         ),
       );
       return container;
@@ -63,6 +68,36 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('filter_price_2')));
       await tester.pump();
       expect(container.read(activeFiltersProvider).priceLevels, {2});
+    });
+
+    testWidgets('save-spot star is hidden without onSaveSpot', (tester) async {
+      final container = await pump(tester);
+      container.read(activeFiltersProvider.notifier).toggleCuisine('mexican');
+      await tester.pump();
+      expect(find.byKey(const ValueKey('filter_save_spot')), findsNothing);
+    });
+
+    testWidgets('save-spot star is hidden when no filters are active', (
+      tester,
+    ) async {
+      await pump(tester, onSaveSpot: () {});
+      expect(find.byKey(const ValueKey('filter_save_spot')), findsNothing);
+    });
+
+    testWidgets('save-spot star appears and fires when filters active', (
+      tester,
+    ) async {
+      var saved = false;
+      final container = await pump(tester, onSaveSpot: () => saved = true);
+      expect(find.byKey(const ValueKey('filter_save_spot')), findsNothing);
+
+      container.read(activeFiltersProvider.notifier).toggleCuisine('mexican');
+      await tester.pump();
+
+      expect(find.byKey(const ValueKey('filter_save_spot')), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('filter_save_spot')));
+      await tester.pump();
+      expect(saved, isTrue);
     });
   });
 }


### PR DESCRIPTION
Implements the deferred ⭐ affordance from #34: turn the filters you've tapped in into a saved **Spot** in one tap.

## What's in it
- A trailing **★ Save Spot** chip appears in the filter bar whenever any filter is active (`filter_save_spot`). Tapping it opens a small dialog: a name field pre-filled from the filters, plus a read-only summary of the area + filters being saved.
- **GPS Spots**: on "Near Me" (no drawn area) the saved Spot is area-less. Recalling it searches the user's **current location** with the saved filters — the common "Near Me + a few filters" case. With an area active, the new Spot reuses that area's polygon + current filters.
- No discovery change needed: `DiscoveryNotifier` already treats a region with <3 vertices as GPS, so an area-less Spot naturally recalls as Near-Me + filters.

## Details
- `SavedRegion.hasArea` — drawn-area vs area-less Spot.
- `SpotFilters.summaryLabel` — `Mexican · Beer · 4.0+` style summary for the suggested name + dialog.
- `FilterChipBar.onSaveSpot` — optional callback; the star is rendered only when set **and** filters are active, keeping the widget reusable.
- `ResultsScreen._onSaveSpot` — name dialog → create/persist Spot → select it → reload chips.

## Tests
- `SavedRegion.hasArea` (polygon / empty / 2-vertex).
- `SpotFilters.summaryLabel` (ordering + friendly cuisine labels).
- Save-star: hidden without callback, hidden with no active filters, appears + fires when filters active.
- Full suite **330 green**, analyze `--fatal-infos --fatal-warnings` clean, format clean.

Next up: the iPad/accessibility-pass infinite-width Detail bug.