### PR TITLE
fix: Detail infinite-width assert on iPad accessibility pass

### DIFF
--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -248,15 +248,25 @@ class DetailScreen extends ConsumerWidget {
             ),
           ),
           const SizedBox(width: 12),
-          OutlinedButton(
-            key: const ValueKey('detail_abort'),
-            onPressed: () => context.pop(),
-            style: OutlinedButton.styleFrom(
-              foregroundColor: GoogieColors.coral,
-              side: const BorderSide(color: GoogieColors.coral, width: 2),
-              padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 24),
+          // Expanded (flexible) so RenderFlex never measures this Material
+          // button with an unbounded main-axis width — an inflexible child here
+          // triggers "BoxConstraints forces an infinite width" during the iPad
+          // accessibility layout pass (the rating buttons below, both Expanded,
+          // never hit this).
+          Expanded(
+            child: OutlinedButton(
+              key: const ValueKey('detail_abort'),
+              onPressed: () => context.pop(),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: GoogieColors.coral,
+                side: const BorderSide(color: GoogieColors.coral, width: 2),
+                padding: const EdgeInsets.symmetric(vertical: 16),
+              ),
+              child: const Text(
+                'Abort Mission',
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
-            child: const Text('Abort Mission'),
           ),
         ],
       ),

--- a/test/screens/detail_screen_render_test.dart
+++ b/test/screens/detail_screen_render_test.dart
@@ -70,6 +70,22 @@ void main() {
     handle.dispose();
   });
 
+  testWidgets('both action buttons are flexible (no unbounded-width row)', (
+    tester,
+  ) async {
+    // The "Abort Mission" button must be Expanded like NAVIGATE. An inflexible
+    // child in the actions Row is measured by RenderFlex with an unbounded
+    // main-axis width, which on the iPad accessibility layout pass triggers
+    // "BoxConstraints forces an infinite width". Keep it flexible.
+    await pumpDetail(tester, const Size(390, 844));
+    final abort = find.byKey(const ValueKey('detail_abort'));
+    expect(abort, findsOneWidget);
+    expect(
+      find.ancestor(of: abort, matching: find.byType(Expanded)),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('renders wide + scrollable with semantics (no infinite width)', (
     tester,
   ) async {


### PR DESCRIPTION
Fixes the long-tracked iPad-only Detail bug: a blank screen + a flood of `BoxConstraints forces an infinite width`, `RenderBox was not laid out`, `parentDataDirty`, and `debugFrameWasSentToEngine` assertions.

## Root cause (reproduced on the iPad Pro 13" simulator)
The first exception in the cascade pointed at `OutlinedButton-[<'detail_abort'>]` ("Abort Mission"). It was the only **inflexible** child of the actions `Row` — `NAVIGATE` is `Expanded`. `RenderFlex._computeSizes` measures inflexible children with an **unbounded main-axis width** to find their natural size; during the iPad accessibility layout pass the button's Material `PhysicalShape` asserts under that infinite width, and everything downstream collapses. The rating-section `Row` (both buttons `Expanded`) never hit this — which is what pointed at the fix.

This only surfaced on the real iPad accessibility pass, not in widget tests (the existing semantics-forced render tests pass both before and after), so it was reproduced live via marionette by temporarily booting straight into Detail, captured from the run log, fixed, and re-verified on a clean boot.

## Fix
Wrap the "Abort Mission" button in `Expanded` (with `TextOverflow.ellipsis`) so no `Row` child is ever measured with an unbounded width.

**Verified:** clean boot into Detail on the iPad Pro 13" simulator → **zero exceptions**, NAVIGATE + Abort render side-by-side.

## Tests
- Regression guard: both action buttons stay flexible (`detail_abort` has an `Expanded` ancestor).
- Full suite **331 green**, analyze `--fatal-infos --fatal-warnings` clean, format clean.