### PR TITLE
feat: tappable phone number on the detail screen

### DIFF
--- a/lib/models/restaurant.dart
+++ b/lib/models/restaurant.dart
@@ -23,6 +23,7 @@ class Restaurant extends Equatable {
     this.outdoorSeating,
     this.goodForGroups,
     this.hasParking,
+    this.phoneNumber,
   });
 
   /// Creates a [Restaurant] from Places API (New) response.
@@ -50,6 +51,7 @@ class Restaurant extends Equatable {
       hasParking: _parseParking(
         json['parkingOptions'] as Map<String, dynamic>?,
       ),
+      phoneNumber: json['nationalPhoneNumber'] as String?,
     );
   }
 
@@ -112,6 +114,10 @@ class Restaurant extends Equatable {
   /// Whether the place has any parking option (null = unknown).
   @HiveField(14)
   final bool? hasParking;
+
+  /// National-format phone number (e.g. "(415) 555-0123"); null = unknown.
+  @HiveField(15)
+  final String? phoneNumber;
 
   /// Parses price level from new API enum string format.
   static String? _parsePriceLevelNew(String? level) {
@@ -182,5 +188,6 @@ class Restaurant extends Equatable {
     outdoorSeating,
     goodForGroups,
     hasParking,
+    phoneNumber,
   ];
 }

--- a/lib/models/restaurant.g.dart
+++ b/lib/models/restaurant.g.dart
@@ -29,13 +29,14 @@ class RestaurantAdapter extends TypeAdapter<Restaurant> {
       outdoorSeating: fields[12] as bool?,
       goodForGroups: fields[13] as bool?,
       hasParking: fields[14] as bool?,
+      phoneNumber: fields[15] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, Restaurant obj) {
     writer
-      ..writeByte(15)
+      ..writeByte(16)
       ..writeByte(0)
       ..write(obj.placeId)
       ..writeByte(1)
@@ -65,7 +66,9 @@ class RestaurantAdapter extends TypeAdapter<Restaurant> {
       ..writeByte(13)
       ..write(obj.goodForGroups)
       ..writeByte(14)
-      ..write(obj.hasParking);
+      ..write(obj.hasParking)
+      ..writeByte(15)
+      ..write(obj.phoneNumber);
   }
 
   @override

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -35,7 +35,7 @@ class DetailScreen extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             _buildHeader(theme),
-            _buildInfo(theme),
+            _buildInfo(context, theme),
             const Divider(height: 32, indent: 16, endIndent: 16),
             _buildActions(context, theme),
             const SizedBox(height: 24),
@@ -91,7 +91,7 @@ class DetailScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildInfo(ThemeData theme) {
+  Widget _buildInfo(BuildContext context, ThemeData theme) {
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Column(
@@ -125,6 +125,11 @@ class DetailScreen extends ConsumerWidget {
               ),
             ],
           ),
+          // Phone — tap to call (useful for checking group availability).
+          if (restaurant.phoneNumber != null) ...[
+            const SizedBox(height: 8),
+            _buildPhoneRow(context, theme, restaurant.phoneNumber!),
+          ],
           const SizedBox(height: 16),
           // Metadata row
           Wrap(
@@ -170,6 +175,40 @@ class DetailScreen extends ConsumerWidget {
             ),
           ],
         ],
+      ),
+    );
+  }
+
+  Widget _buildPhoneRow(
+    BuildContext context,
+    ThemeData theme,
+    String phoneNumber,
+  ) {
+    return InkWell(
+      key: const ValueKey('detail_call'),
+      onTap: () => _callPhone(context, phoneNumber),
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          children: [
+            const Icon(
+              Icons.phone,
+              size: 18,
+              color: GoogieColors.turquoise,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                phoneNumber,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: GoogieColors.turquoise,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -404,6 +443,25 @@ class DetailScreen extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  Future<void> _callPhone(BuildContext context, String phoneNumber) async {
+    // Keep digits and a leading + so the dialer gets a clean tel: URI.
+    final sanitized = phoneNumber.replaceAll(RegExp('[^0-9+]'), '');
+    final url = Uri(scheme: 'tel', path: sanitized);
+
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url);
+    } else {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Unable to place the call'),
+            backgroundColor: GoogieColors.coral,
+          ),
+        );
+      }
+    }
   }
 
   Future<void> _openMaps(BuildContext context) async {

--- a/lib/services/places_service.dart
+++ b/lib/services/places_service.dart
@@ -53,6 +53,7 @@ class PlacesService {
       'places.priceLevel,'
       'places.photos,'
       'places.primaryType,'
+      'places.nationalPhoneNumber,'
       'places.currentOpeningHours';
 
   /// Extra ("atmosphere") fields, requested only when an atmosphere filter is

--- a/test/models/restaurant_test.dart
+++ b/test/models/restaurant_test.dart
@@ -52,6 +52,7 @@ void main() {
         null, // outdoorSeating
         null, // goodForGroups
         null, // hasParking
+        null, // phoneNumber
       ]);
     });
 
@@ -87,6 +88,7 @@ void main() {
           ],
           'primaryType': 'restaurant',
           'types': ['restaurant', 'food', 'establishment'],
+          'nationalPhoneNumber': '(415) 555-0123',
           'currentOpeningHours': {'openNow': true},
         };
 
@@ -103,6 +105,7 @@ void main() {
         expect(result.photoReference, 'places/abc/photos/xyz');
         expect(result.types, contains('restaurant'));
         expect(result.isOpen, true);
+        expect(result.phoneNumber, '(415) 555-0123');
       });
 
       test('handles missing optional fields', () {
@@ -122,6 +125,7 @@ void main() {
         expect(result.photoReference, isNull);
         expect(result.isOpen, isNull);
         expect(result.totalRatings, isNull);
+        expect(result.phoneNumber, isNull);
       });
 
       test('handles null id', () {

--- a/test/screens/detail_screen_render_test.dart
+++ b/test/screens/detail_screen_render_test.dart
@@ -70,6 +70,38 @@ void main() {
     handle.dispose();
   });
 
+  testWidgets('shows a tappable phone row when a number is present', (
+    tester,
+  ) async {
+    const withPhone = Restaurant(
+      placeId: 'p9',
+      name: 'Phone Diner',
+      address: '1 Call St',
+      latitude: 34,
+      longitude: -118,
+      isOpen: true,
+      phoneNumber: '(415) 555-0123',
+    );
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = const Size(390, 844);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(home: DetailScreen(restaurant: withPhone)),
+      ),
+    );
+    await tester.pump();
+    expect(find.byKey(const ValueKey('detail_call')), findsOneWidget);
+    expect(find.text('(415) 555-0123'), findsOneWidget);
+  });
+
+  testWidgets('hides the phone row when no number is present', (tester) async {
+    // The module-level `restaurant` has no phoneNumber.
+    await pumpDetail(tester, const Size(390, 844));
+    expect(find.byKey(const ValueKey('detail_call')), findsNothing);
+  });
+
   testWidgets('both action buttons are flexible (no unbounded-width row)', (
     tester,
   ) async {


### PR DESCRIPTION
Adds a way to **call the restaurant** from the detail screen — e.g. to check whether a place can accommodate a large group.

## What's in it
- `Restaurant.phoneNumber` (Hive field 15), parsed from the Places API (New) `nationalPhoneNumber` field. That field is in the same Enterprise SKU tier we already pay for (`rating`/`priceLevel`), so there's no new pricing tier — just added to the search field mask.
- Detail screen shows a **tappable phone row** (phone icon + number, `ValueKey('detail_call')`) right below the address when a number is available. Tapping launches the dialer via a sanitized `tel:` URI. The row is hidden when no number is present.

## Verified
Booted the app on the iPad Pro 13" simulator with **live Places data** → real number fetched, parsed, and rendered (e.g. Kokkari Estiatorio → 📞 (415) 981-0983). Tapping opens the dialer on device (simulator has no dialer, so it shows a graceful "Unable to place the call" snackbar).

## Tests
- `fromPlacesApiNew` parses `nationalPhoneNumber` (present) and leaves it null when absent; props updated.
- Detail render: phone row shows with a number, hidden without.
- Full suite **333 green**, analyze `--fatal-infos --fatal-warnings` clean, format clean.