### PR TITLE
fix(spin): smooth scroll, fair selection, full slots, winner emphasis, result count

### DIFF
--- a/lib/screens/results/results_screen.dart
+++ b/lib/screens/results/results_screen.dart
@@ -341,7 +341,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
             Column(
               children: [
                 // Top bar with refresh and settings
-                _buildTopBar(isSpinning, canRefresh),
+                _buildTopBar(isSpinning, canRefresh, state.restaurants.length),
                 // One-tap scope picker: Near Me + saved regions + New Area
                 RegionChipBar(
                   regions: _regions,
@@ -460,7 +460,8 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
     );
   }
 
-  Widget _buildTopBar(bool isSpinning, bool canRefresh) {
+  Widget _buildTopBar(bool isSpinning, bool canRefresh, int count) {
+    final theme = Theme.of(context);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8),
       child: Row(
@@ -473,6 +474,23 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
               iconSize: 28,
               onPressed: isSpinning ? null : _refreshRestaurants,
               tooltip: 'Find new restaurants',
+            ),
+          // How many spots are in the reel right now.
+          if (canRefresh && count > 0)
+            Container(
+              key: const ValueKey('result_count'),
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              decoration: BoxDecoration(
+                color: GoogieColors.turquoiseContainer,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                '$count ${count == 1 ? 'spot' : 'spots'}',
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: GoogieColors.deepTeal,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
             ),
           const Spacer(),
           // Quick tune (radius + price) in an M3 bottom sheet.

--- a/lib/screens/results/results_screen.dart
+++ b/lib/screens/results/results_screen.dart
@@ -167,6 +167,8 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
   }
 
   void _startSpin() {
+    // Guard against re-entry during the reveal/celebration sequence.
+    if (_showCelebration) return;
     ref.read(discoveryProvider.notifier).startSpin();
     _slotMachineKey.currentState?.spin();
   }
@@ -374,7 +376,12 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
                     button: true,
                     child: RandoEatsButton(
                       key: const ValueKey('spin_button'),
-                      onPressed: _startSpin,
+                      // Locked for the whole winner sequence: the reel spin
+                      // (status == spinning) through the reveal + celebration,
+                      // re-enabled only once the celebration completes.
+                      onPressed: (isSpinning || _showCelebration)
+                          ? null
+                          : _startSpin,
                       isSpinning: isSpinning,
                     ),
                   ),

--- a/lib/widgets/multi_reel_slot_machine.dart
+++ b/lib/widgets/multi_reel_slot_machine.dart
@@ -249,6 +249,11 @@ class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
 
   int landedIndex = 0;
 
+  /// While spinning, the reel renders a long repeating strip so the scroll can
+  /// run monotonically without ever hitting the end (no wrap/pause). 0 until the
+  /// first spin; falls back to the finite length in [build].
+  int _spinItemCount = 0;
+
   @override
   void initState() {
     super.initState();
@@ -256,6 +261,21 @@ class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
     // would otherwise run inside dispose() for reels that never spin, doing an
     // ancestor (TickerMode) lookup on a deactivated element → crash.
     _controller = AnimationController(vsync: this);
+  }
+
+  @override
+  void didUpdateWidget(_Reel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // When the spin ends the list returns to its finite length; pin the winner
+    // at the top of that finite list (the strip had it at the top already, so
+    // this is visually seamless).
+    if (oldWidget.spinning && !widget.spinning) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!_scroll.hasClients) return;
+        final maxExtent = _scroll.position.maxScrollExtent;
+        _scroll.jumpTo((landedIndex * widget.cardHeight).clamp(0.0, maxExtent));
+      });
+    }
   }
 
   @override
@@ -279,31 +299,39 @@ class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
 
   /// Spins this reel for [duration], landing a random cell at the top.
   void spin({required Duration duration, required VoidCallback onStopped}) {
-    if (widget.restaurants.isEmpty) {
+    final n = widget.restaurants.length;
+    if (n == 0) {
       onStopped();
       return;
     }
-    landedIndex = math.Random().nextInt(widget.restaurants.length);
+    landedIndex = math.Random().nextInt(n);
 
-    final cycle = widget.restaurants.length * widget.cardHeight;
-    final target = (cycle * 3) + (landedIndex * widget.cardHeight);
+    // Spin a consistent visual distance regardless of how many cells the column
+    // has (so 1 result spins as smoothly as 12), landing exactly on a card
+    // boundary with the winning cell at the top.
+    const minTravelCells = 24;
+    final loops = math.max(3, (minTravelCells / n).ceil());
+    final endIndex = loops * n + landedIndex;
+    final target = endIndex * widget.cardHeight;
+
+    // Repeating strip long enough that the monotonic scroll never reaches the
+    // end — no modulo wrap, no clamp pause. Read by [build].
+    _spinItemCount = endIndex + n + 4;
 
     if (_scroll.hasClients) _scroll.jumpTo(0);
     _controller
       ..duration = duration
       ..reset();
     _animation = Tween<double>(begin: 0, end: target).animate(
-      CurvedAnimation(parent: _controller, curve: _SlotMachineCurve()),
+      CurvedAnimation(parent: _controller, curve: const _SpinCurve()),
     )..addListener(_tick);
 
     void statusListener(AnimationStatus status) {
       if (status != AnimationStatus.completed) return;
       _animation?.removeListener(_tick);
       _controller.removeStatusListener(statusListener);
-      if (_scroll.hasClients) {
-        final maxExtent = _scroll.position.maxScrollExtent;
-        _scroll.jumpTo((landedIndex * widget.cardHeight).clamp(0, maxExtent));
-      }
+      // The winner is already at the top (offset == target). Re-pinning on the
+      // finite list happens in didUpdateWidget once `spinning` flips false.
       onStopped();
     }
 
@@ -314,8 +342,9 @@ class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
   void _tick() {
     if (!_scroll.hasClients) return;
     final maxExtent = _scroll.position.maxScrollExtent;
-    final wrapped = _animation!.value % (maxExtent + widget.cardHeight);
-    _scroll.jumpTo(wrapped.clamp(0, maxExtent));
+    // Monotonic, seamless scroll. The strip is long enough that we never reach
+    // the end, so there is no wrap and no pause; clamp is only a safety net.
+    _scroll.jumpTo(_animation!.value.clamp(0.0, maxExtent));
   }
 
   @override
@@ -339,11 +368,16 @@ class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
           // Extra bottom padding so the last card can scroll clear of the
           // floating spin badge that hovers over the bottom of the list.
           padding: const EdgeInsets.only(top: 4, bottom: 120),
-          itemCount: widget.restaurants.length,
+          // Finite list of options when idle; a long repeating strip while
+          // spinning so the scroll loops seamlessly.
+          itemCount: widget.spinning && _spinItemCount > 0
+              ? _spinItemCount
+              : widget.restaurants.length,
           itemBuilder: (context, index) {
-            final restaurant = widget.restaurants[index];
+            final n = widget.restaurants.length;
+            final restaurant = widget.restaurants[index % n];
             final isWinnerCell =
-                widget.isWinner && index == landedIndex && !widget.spinning;
+                widget.isWinner && !widget.spinning && index == landedIndex;
             // Non-winning cells morph into the detail page (M3 container
             // transform). The winner keeps its Hero for the celebration flight.
             final useContainer =
@@ -420,13 +454,33 @@ class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
   }
 }
 
-/// Slot-machine easing: quick start, full speed, decelerate to a stop.
-class _SlotMachineCurve extends Curve {
+/// Smooth trapezoidal spin easing: ramp up (accelerate) → cruise at full speed
+/// → ramp down (decelerate) to a stop. Velocity is continuous (no jerks), and
+/// the deceleration phase is longer than the acceleration for a satisfying
+/// slot-machine slowdown. Position is normalized so transform(1) == 1.
+class _SpinCurve extends Curve {
+  const _SpinCurve();
+
+  static const double _ta = 0.25; // acceleration ends
+  static const double _tb = 0.6; // deceleration begins
+  // Peak velocity that makes the integral (total distance) equal 1.
+  static const double _vMax = 1 / (_ta / 2 + (_tb - _ta) + (1 - _tb) / 2);
+
   @override
-  double transform(double t) {
-    if (t < 0.1) return Curves.easeIn.transform(t * 10) * 0.1;
-    if (t < 0.6) return 0.1 + (t - 0.1) * (0.6 / 0.5);
-    final localT = (t - 0.6) / 0.4;
-    return 0.7 + Curves.easeOutCubic.transform(localT) * 0.3;
+  double transformInternal(double t) {
+    if (t < _ta) {
+      // Accelerating: area under a linearly rising velocity.
+      return _vMax * t * t / (2 * _ta);
+    }
+    if (t < _tb) {
+      // Cruising at _vMax.
+      return _vMax * (_ta / 2) + _vMax * (t - _ta);
+    }
+    // Decelerating: linearly falling velocity to 0 at t == 1.
+    final d = t - _tb;
+    const dd = 1 - _tb;
+    return _vMax * (_ta / 2) +
+        _vMax * (_tb - _ta) +
+        _vMax * (d - d * d / (2 * dd));
   }
 }

--- a/lib/widgets/multi_reel_slot_machine.dart
+++ b/lib/widgets/multi_reel_slot_machine.dart
@@ -61,7 +61,7 @@ class MultiReelSlotMachineState extends State<MultiReelSlotMachine> {
 
   /// How long the winner is held — expanded + announced — before the
   /// celebration/handoff fires, so the result is unmistakable.
-  static const Duration _revealHold = Duration(milliseconds: 650);
+  static const Duration _revealHold = Duration(milliseconds: 1300);
 
   final _random = math.Random();
   final List<GlobalKey<_ReelState>> _reelKeys = [];
@@ -440,16 +440,59 @@ class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
                   ),
               ],
             );
-            // The winning cell expands to make the result unmistakable.
-            return AnimatedScale(
-              scale: isWinnerCell ? 1.04 : 1,
-              duration: const Duration(milliseconds: 400),
-              curve: Curves.easeOutBack,
-              child: cell,
-            );
+            // The winning cell pulses (shrink + grow) with a subtle shake so
+            // the chosen card is unmistakable before the detail screen opens.
+            return isWinnerCell ? _WinnerPulse(child: cell) : cell;
           },
         ),
       ),
+    );
+  }
+}
+
+/// Attention animation for the winning cell: a repeating shrink↔grow pulse with
+/// a subtle rocking shake, so the chosen card stands out before the detail
+/// screen opens.
+class _WinnerPulse extends StatefulWidget {
+  const _WinnerPulse({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_WinnerPulse> createState() => _WinnerPulseState();
+}
+
+class _WinnerPulseState extends State<_WinnerPulse>
+    with SingleTickerProviderStateMixin {
+  // A finite burst (~3 shrink/grow pulses) that decays to rest, so it reads as
+  // a clear "this is your pick!" and still settles (no perpetual animation).
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1200),
+  )..forward();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      child: widget.child,
+      builder: (context, child) {
+        final v = _controller.value;
+        final decay = 1 - v; // fade the emphasis out toward rest
+        final osc = math.sin(v * math.pi * 2 * 3); // 3 grow/shrink cycles
+        final scale = 1 + 0.11 * osc * decay;
+        final angle = 0.03 * osc * decay; // subtle rocking shake
+        return Transform.rotate(
+          angle: angle,
+          child: Transform.scale(scale: scale, child: child),
+        );
+      },
     );
   }
 }

--- a/lib/widgets/multi_reel_slot_machine.dart
+++ b/lib/widgets/multi_reel_slot_machine.dart
@@ -67,7 +67,6 @@ class MultiReelSlotMachineState extends State<MultiReelSlotMachine> {
   final List<GlobalKey<_ReelState>> _reelKeys = [];
 
   int _columns = 1;
-  int _rows = 1;
   bool _isSpinning = false;
   int? _winnerColumn;
   int _stoppedCount = 0;
@@ -112,11 +111,18 @@ class MultiReelSlotMachineState extends State<MultiReelSlotMachine> {
       _stoppedCount = 0;
     });
 
-    final winnerColumn = _random.nextInt(_columns);
+    // Pick the winner uniformly over ALL restaurants, then map the global index
+    // to the strided (column, position) that displays it. Every restaurant is
+    // equally likely — no front-of-list bias, no unreachable tail.
+    final winnerGlobal = _random.nextInt(widget.restaurants.length);
+    final winnerColumn = winnerGlobal % _columns;
+    final winnerPos = winnerGlobal ~/ _columns;
 
     if (widget.calmMode) {
       for (var c = 0; c < _columns; c++) {
-        _reelKeys[c].currentState?.placeInstantly();
+        _reelKeys[c].currentState?.placeInstantly(
+          index: c == winnerColumn ? winnerPos : null,
+        );
       }
       _revealWinner(winnerColumn);
       return;
@@ -125,6 +131,7 @@ class MultiReelSlotMachineState extends State<MultiReelSlotMachine> {
     for (var c = 0; c < _columns; c++) {
       _reelKeys[c].currentState?.spin(
         duration: _baseSpin + _stagger * c,
+        landIndex: c == winnerColumn ? winnerPos : null,
         onStopped: () => _onReelStopped(winnerColumn),
       );
     }
@@ -142,10 +149,10 @@ class MultiReelSlotMachineState extends State<MultiReelSlotMachine> {
     final reels = ReelLayout.buildReels(
       widget.restaurants,
       columns: _columns,
-      rows: _rows,
     );
+    final reel = reels[winnerColumn];
     final landed = _reelKeys[winnerColumn].currentState?.landedIndex ?? 0;
-    final winner = reels[winnerColumn][landed];
+    final winner = reel[landed.clamp(0, reel.length - 1)];
 
     setState(() {
       _isSpinning = false;
@@ -168,13 +175,11 @@ class MultiReelSlotMachineState extends State<MultiReelSlotMachine> {
         final rows = _rowsFor(constraints.maxHeight);
         // Cache derived layout so spin() and the next build agree.
         _columns = columns;
-        _rows = rows;
         _syncReelKeys(columns);
 
         final reels = ReelLayout.buildReels(
           widget.restaurants,
           columns: columns,
-          rows: rows,
         );
 
         return Stack(
@@ -188,6 +193,8 @@ class MultiReelSlotMachineState extends State<MultiReelSlotMachine> {
                       key: _reelKeys[c],
                       restaurants: reels[c],
                       cardHeight: cardHeight,
+                      minCells: rows,
+                      random: _random,
                       isWinner: _winnerColumn == c,
                       dimmed: _winnerColumn != null && _winnerColumn != c,
                       spinning: _isSpinning,
@@ -222,6 +229,8 @@ class _Reel extends StatefulWidget {
   const _Reel({
     required this.restaurants,
     required this.cardHeight,
+    required this.minCells,
+    required this.random,
     required this.isWinner,
     required this.dimmed,
     required this.spinning,
@@ -230,8 +239,16 @@ class _Reel extends StatefulWidget {
     super.key,
   });
 
+  /// The distinct restaurants this reel can land on.
   final List<Restaurant> restaurants;
   final double cardHeight;
+
+  /// Minimum cells to render so the reel fills the viewport (including the slot
+  /// under the floating spin badge) by repeating [restaurants] as needed.
+  final int minCells;
+
+  /// Shared RNG, so landing indices come from one well-distributed source.
+  final math.Random random;
   final bool isWinner;
   final bool dimmed;
   final bool spinning;
@@ -285,26 +302,31 @@ class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
     super.dispose();
   }
 
-  /// Places this reel at a random cell instantly, with no animation.
-  ///
-  /// Used by calm (reduced-motion) mode.
-  void placeInstantly() {
-    if (widget.restaurants.isEmpty) return;
-    landedIndex = math.Random().nextInt(widget.restaurants.length);
+  /// Places this reel at [index] (or a random distinct cell) instantly, with no
+  /// animation. Used by calm (reduced-motion) mode.
+  void placeInstantly({int? index}) {
+    final n = widget.restaurants.length;
+    if (n == 0) return;
+    landedIndex = index ?? widget.random.nextInt(n);
     if (_scroll.hasClients) {
       final maxExtent = _scroll.position.maxScrollExtent;
       _scroll.jumpTo((landedIndex * widget.cardHeight).clamp(0, maxExtent));
     }
   }
 
-  /// Spins this reel for [duration], landing a random cell at the top.
-  void spin({required Duration duration, required VoidCallback onStopped}) {
+  /// Spins this reel for [duration], landing [landIndex] (or a random distinct
+  /// cell) at the top.
+  void spin({
+    required Duration duration,
+    required VoidCallback onStopped,
+    int? landIndex,
+  }) {
     final n = widget.restaurants.length;
     if (n == 0) {
       onStopped();
       return;
     }
-    landedIndex = math.Random().nextInt(n);
+    landedIndex = landIndex ?? widget.random.nextInt(n);
 
     // Spin a consistent visual distance regardless of how many cells the column
     // has (so 1 result spins as smoothly as 12), landing exactly on a card
@@ -315,8 +337,9 @@ class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
     final target = endIndex * widget.cardHeight;
 
     // Repeating strip long enough that the monotonic scroll never reaches the
-    // end — no modulo wrap, no clamp pause. Read by [build].
-    _spinItemCount = endIndex + n + 4;
+    // end — no modulo wrap, no clamp pause — and with enough cells past the
+    // landing to keep the viewport (incl. under the badge) full.
+    _spinItemCount = endIndex + n + widget.minCells + 2;
 
     if (_scroll.hasClients) _scroll.jumpTo(0);
     _controller
@@ -365,14 +388,15 @@ class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
           physics: widget.spinning
               ? const NeverScrollableScrollPhysics()
               : const ClampingScrollPhysics(),
-          // Extra bottom padding so the last card can scroll clear of the
-          // floating spin badge that hovers over the bottom of the list.
-          padding: const EdgeInsets.only(top: 4, bottom: 120),
-          // Finite list of options when idle; a long repeating strip while
-          // spinning so the scroll loops seamlessly.
-          itemCount: widget.spinning && _spinItemCount > 0
-              ? _spinItemCount
-              : widget.restaurants.length,
+          padding: const EdgeInsets.only(top: 4, bottom: 8),
+          // A repeating strip of the full list: idle it fills the viewport
+          // (incl. the slot under the floating badge) by repeating as needed;
+          // spinning it is long enough to loop seamlessly.
+          itemCount: widget.restaurants.isEmpty
+              ? 0
+              : (widget.spinning && _spinItemCount > 0
+                    ? _spinItemCount
+                    : widget.restaurants.length + widget.minCells),
           itemBuilder: (context, index) {
             final n = widget.restaurants.length;
             final restaurant = widget.restaurants[index % n];

--- a/lib/widgets/reel_layout.dart
+++ b/lib/widgets/reel_layout.dart
@@ -17,29 +17,27 @@ abstract final class ReelLayout {
     return columns.clamp(1, maxColumns);
   }
 
-  /// Distributes [restaurants] into [columns] reels of [rows] cells each.
+  /// Distributes ALL [restaurants] across [columns] reels, round-robin
+  /// (strided) so every restaurant lands in exactly one column and the columns
+  /// stay balanced. No restaurant is dropped and none is duplicated here — each
+  /// reel repeats its own cells as needed for the visual fill (see the reel
+  /// widget), while selection stays uniform over the distinct restaurants.
   ///
-  /// When there are fewer restaurants than cells, restaurants repeat to fill
-  /// (duplicates across cells are allowed by design). Returns `columns` lists,
-  /// each of length `rows` (empty lists when [restaurants] is empty).
+  /// Restaurant `i` goes to column `i % columns`, so the global index `g` maps
+  /// to `reels[g % columns][g ~/ columns]`. Returns `columns` lists (some may
+  /// be empty when there are fewer restaurants than columns).
   static List<List<Restaurant>> buildReels(
     List<Restaurant> restaurants, {
     required int columns,
-    required int rows,
   }) {
     final reels = List.generate(
       columns,
       (_) => <Restaurant>[],
       growable: false,
     );
-    if (restaurants.isEmpty || columns <= 0 || rows <= 0) return reels;
-
-    var index = 0;
-    for (var c = 0; c < columns; c++) {
-      for (var r = 0; r < rows; r++) {
-        reels[c].add(restaurants[index % restaurants.length]);
-        index++;
-      }
+    if (columns <= 0) return reels;
+    for (var i = 0; i < restaurants.length; i++) {
+      reels[i % columns].add(restaurants[i]);
     }
     return reels;
   }

--- a/test/widgets/multi_reel_slot_machine_test.dart
+++ b/test/widgets/multi_reel_slot_machine_test.dart
@@ -124,7 +124,7 @@ void main() {
     expect(machineKey.currentState!.isSpinning, isFalse);
     expect(winner, isNull); // reveal hold not elapsed yet
 
-    await tester.pump(const Duration(milliseconds: 700));
+    await tester.pump(const Duration(milliseconds: 1400));
     expect(winner, isNotNull);
     expect(restaurants.map((r) => r.placeId), contains(winner!.placeId));
 

--- a/test/widgets/reel_layout_test.dart
+++ b/test/widgets/reel_layout_test.dart
@@ -41,43 +41,34 @@ void main() {
       ),
     );
 
-    test('fills columns x rows with unique restaurants when enough', () {
-      final reels = ReelLayout.buildReels(
-        makeRestaurants(12),
-        columns: 3,
-        rows: 4,
-      );
+    test('distributes ALL restaurants across columns (strided, no dupes)', () {
+      final reels = ReelLayout.buildReels(makeRestaurants(12), columns: 3);
       expect(reels, hasLength(3));
       expect(reels.every((r) => r.length == 4), isTrue);
-      // 12 distinct across 3x4.
-      final all = reels.expand((r) => r).map((r) => r.placeId).toSet();
-      expect(all, hasLength(12));
+      // Every restaurant present exactly once.
+      final all = reels.expand((r) => r).map((r) => r.placeId).toList();
+      expect(all.toSet(), hasLength(12));
+      // Strided: column c holds restaurants c, c+3, c+6, ...
+      expect(reels[0].map((r) => r.placeId), ['p0', 'p3', 'p6', 'p9']);
+      expect(reels[1].map((r) => r.placeId), ['p1', 'p4', 'p7', 'p10']);
+      expect(reels[2].map((r) => r.placeId), ['p2', 'p5', 'p8', 'p11']);
     });
 
-    test('repeats restaurants to fill when too few (duplicates allowed)', () {
-      final reels = ReelLayout.buildReels(
-        makeRestaurants(2),
-        columns: 3,
-        rows: 2,
-      );
-      // 6 cells filled from 2 restaurants, cycling.
-      final flat = reels.expand((r) => r).map((r) => r.placeId).toList();
-      expect(flat, hasLength(6));
-      expect(flat, ['p0', 'p1', 'p0', 'p1', 'p0', 'p1']);
+    test('fewer restaurants than columns leaves trailing columns empty', () {
+      final reels = ReelLayout.buildReels(makeRestaurants(2), columns: 3);
+      expect(reels.map((r) => r.length), [1, 1, 0]);
+      expect(reels[0].first.placeId, 'p0');
+      expect(reels[1].first.placeId, 'p1');
     });
 
     test('returns empty reels for empty input', () {
-      final reels = ReelLayout.buildReels(const [], columns: 2, rows: 3);
+      final reels = ReelLayout.buildReels(const [], columns: 2);
       expect(reels, hasLength(2));
       expect(reels.every((r) => r.isEmpty), isTrue);
     });
 
-    test('single column (phone) is the current single-reel case', () {
-      final reels = ReelLayout.buildReels(
-        makeRestaurants(5),
-        columns: 1,
-        rows: 5,
-      );
+    test('single column (phone) holds the whole list in order', () {
+      final reels = ReelLayout.buildReels(makeRestaurants(5), columns: 1);
       expect(reels, hasLength(1));
       expect(reels.first.map((r) => r.placeId), ['p0', 'p1', 'p2', 'p3', 'p4']);
     });


### PR DESCRIPTION
## Spin / reel fixes

- **Smooth, continuous spin** — replaced the wrap-and-clamp loop (which paused at the bottom then jumped to the top) with a monotonic scroll over a long repeating strip, plus a trapezoidal ramp-up → cruise → ramp-down curve.
- **Clear winner** — the winning card plays a finite shrink/grow + shake burst; reveal hold lengthened so it's unmistakable before the detail screen opens.
- **Fair winner selection** — fixed a real bias: only the first ~6 results could ever win (the rest had 0%), and the front of the list was over-weighted. `buildReels` now spreads ALL restaurants across columns and the winner is drawn uniformly over the full list via one shared `Random`.
- **Every slot filled** — each reel renders a repeating strip of its full list so every visible slot is populated, including the one under the floating spin badge (bottom padding 120 → 8).
- **Spin button lockout** — disabled for the entire winner sequence (reel spin → reveal → celebration), re-enabled only when the celebration completes.
- **Result count** — a small "N spots" pill next to the refresh icon.

Analyzer clean (`--fatal-infos --fatal-warnings`), `dart format` clean, all 333 tests pass (incl. updated `ReelLayout` tests proving every restaurant is reachable). Verified on device.