### PR TITLE
Differentiate Summer theme + web Places key setup

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -79,6 +79,7 @@
     "mostrado",
     "myusername",
     "Namecheap",
+    "Referer",
     "Nanode",
     "NBGK",
     "nearbysearch",

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -36,7 +36,8 @@ jobs:
         run: |
           flutter build web \
             --release \
-            -t lib/main_production.dart
+            -t lib/main_production.dart \
+            --dart-define=GOOGLE_PLACES_API_KEY=${{ secrets.GOOGLE_PLACES_API_KEY }}
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4

--- a/docs/WEB_SETUP.md
+++ b/docs/WEB_SETUP.md
@@ -1,0 +1,137 @@
+# Getting the Web App Working (Google Places API key)
+
+The web build (randoeats.com, deployed to Cloudflare Pages) currently comes up
+but returns **no restaurants**. This is because the Google Places API key is
+**not injected into the web build**.
+
+`lib/services/places_service.dart` reads the key at compile time:
+
+```dart
+static const _apiKey = String.fromEnvironment('GOOGLE_PLACES_API_KEY');
+```
+
+Locally and for mobile we pass it via `--dart-define-from-file=.env`. But
+`.github/workflows/deploy-web.yml` builds web with **no `--dart-define`**, so on
+the web `_apiKey` is an empty string and every Places request fails.
+
+There are two parts: (1) inject a key into the web build, and (2) make sure that
+key actually works from a browser (CORS + restrictions).
+
+---
+
+## ⚠️ Important: web has two extra constraints mobile doesn't
+
+1. **The key ships to the browser.** Anything in a web build is public. A web
+   Places key MUST be locked down with an **HTTP referrer restriction**
+   (`randoeats.com/*`) so it can't be reused elsewhere. Do **not** reuse the
+   unrestricted server/mobile key.
+2. **CORS.** The app calls `https://places.googleapis.com` directly. Browser
+   (cross-origin) calls to the Places API can be blocked by CORS. If, after
+   injecting the key, the browser console shows CORS errors, the direct-call
+   approach won't work on web and you need the **server proxy** described in
+   [`BACKEND_PROXY_PLAN.md`](BACKEND_PROXY_PLAN.md) (recommended end state
+   anyway, since it also keeps the key off the client). Mobile is unaffected.
+
+---
+
+## Step 1 — Create a web-restricted Places API key
+
+In the [Google Cloud Console](https://console.cloud.google.com/) for the
+randoeats project:
+
+1. **APIs & Services → Library** → enable **Places API (New)** (and **Maps
+   JavaScript API** if the web app renders maps).
+2. **APIs & Services → Credentials → Create credentials → API key**.
+3. Edit the new key:
+   - **Application restrictions → Websites (HTTP referrers)** and add:
+     - `https://randoeats.com/*`
+     - `https://*.randoeats.com/*`
+     - `https://<your-cloudflare-pages-subdomain>.pages.dev/*` (for preview)
+     - `http://localhost:*/*` (for local `flutter run -d chrome`)
+   - **API restrictions → Restrict key** → select **Places API (New)** (and
+     Maps JavaScript API if used).
+4. Copy the key value.
+
+> Keep this **separate** from the mobile/server key. It's a public, referrer-
+> locked, web-only key.
+
+## Step 2 — Add the key as a GitHub Actions secret
+
+The deploy workflow runs in the `production` environment, so add the secret
+there (or as a repo secret).
+
+**Via the GitHub UI:** Repo → **Settings → Secrets and variables → Actions** →
+(Environment `production`) → **New secret**:
+- Name: `GOOGLE_PLACES_API_KEY`
+- Value: *the web key from Step 1*
+
+**Or via the CLI** (run it yourself so the value isn't logged — in this session
+prefix with `!`):
+
+```bash
+gh secret set GOOGLE_PLACES_API_KEY --env production
+# paste the key when prompted
+```
+
+## Step 3 — Inject the key into the web build
+
+Edit `.github/workflows/deploy-web.yml` so the build step passes the key:
+
+```yaml
+      - name: Build Flutter Web
+        run: |
+          flutter build web \
+            --release \
+            -t lib/main_production.dart \
+            --dart-define=GOOGLE_PLACES_API_KEY=${{ secrets.GOOGLE_PLACES_API_KEY }}
+```
+
+(That's the only change — add the trailing `--dart-define` line.)
+
+## Step 4 — Redeploy
+
+Either push to `main` (the workflow runs on changes under `lib/**`,
+`pubspec.yaml`, or the workflow file) or trigger it manually:
+
+```bash
+gh workflow run deploy-web.yml --ref main
+```
+
+## Step 5 — Verify
+
+1. Open https://randoeats.com, open the browser **DevTools → Network/Console**.
+2. Spin / load results.
+   - **Restaurants appear** → done. ✅
+   - **403 / "API key not valid" / "RefererNotAllowed"** → the key restriction
+     or API enablement is wrong (revisit Step 1; confirm the live origin is in
+     the referrer list).
+   - **CORS errors** (`No 'Access-Control-Allow-Origin'`) → direct browser calls
+     are blocked; switch web to the proxy in
+     [`BACKEND_PROXY_PLAN.md`](BACKEND_PROXY_PLAN.md).
+
+---
+
+## Local web testing
+
+You can test the web build locally with your existing `.env`:
+
+```bash
+flutter run -d chrome --dart-define-from-file=.env -t lib/main_staging.dart
+# or a release build:
+flutter build web -t lib/main_production.dart --dart-define-from-file=.env
+```
+
+If it works locally but not on randoeats.com, the difference is almost always
+the **referrer restriction** (localhost is allowed, the live origin isn't) or
+the **missing GitHub secret**.
+
+---
+
+## Notes / recommended end state
+
+- Photos are loaded via a URL that embeds the key, so the web key is also
+  visible in image requests — another reason to keep it referrer-restricted.
+- The durable fix for web (and for key safety generally) is the **backend
+  proxy** in [`BACKEND_PROXY_PLAN.md`](BACKEND_PROXY_PLAN.md): the browser calls
+  our API, which holds the key server-side and resolves CORS. Once that exists,
+  the web build needs no Places key at all.

--- a/lib/config/theme.dart
+++ b/lib/config/theme.dart
@@ -169,27 +169,29 @@ class GoogiePalette {
     brightness: Brightness.dark,
   );
 
-  /// Summer — sunny, hot: sandy background, sea-teal, hot coral, sun gold.
+  /// Summer — hot beach at golden hour: deep tropical sea-teal over warm golden
+  /// sand, with a blazing sunset orange and bold marigold. Pushed warmer and
+  /// more saturated than Spring's pale, fresh aqua so the two read distinctly.
   static const summer = GoogiePalette(
-    turquoise: Color(0xFF00BFA6),
-    deepTeal: Color(0xFF0E6E63),
-    coral: Color(0xFFFF5A4D),
-    mustard: Color(0xFFFFAF14),
-    cream: Color(0xFFFFF4E2),
-    chrome: Color(0xFFE8D4B8),
-    spaceBlack: Color(0xFF3A2A1A),
+    turquoise: Color(0xFF00A896),
+    deepTeal: Color(0xFF00695C),
+    coral: Color(0xFFFF4D2E),
+    mustard: Color(0xFFFF9E1B),
+    cream: Color(0xFFFFE6BE),
+    chrome: Color(0xFFE6C79C),
+    spaceBlack: Color(0xFF3A2615),
     white: Color(0xFFFFFFFF),
     darkCard: Color(0xFF2D2D44),
     statusOpen: Color(0xFF2E7D5B),
     statusClosed: Color(0xFFC4452F),
-    turquoiseContainer: Color(0xFFBFF0E8),
-    onTurquoiseContainer: Color(0xFF06423C),
-    coralContainer: Color(0xFFFFDAD2),
-    onCoralContainer: Color(0xFF5A160B),
-    mustardContainer: Color(0xFFFFE8B0),
-    onMustardContainer: Color(0xFF3F2E00),
+    turquoiseContainer: Color(0xFFAEE9DF),
+    onTurquoiseContainer: Color(0xFF003B34),
+    coralContainer: Color(0xFFFFD8CB),
+    onCoralContainer: Color(0xFF5A1606),
+    mustardContainer: Color(0xFFFFDF9E),
+    onMustardContainer: Color(0xFF402B00),
     statusOpenContainer: Color(0xFFCFEBD9),
-    cardTint: Color(0xFFFFF1DD),
+    cardTint: Color(0xFFFFEFC9),
     brightness: Brightness.light,
   );
 


### PR DESCRIPTION
- **Summer theme** pushed warmer/more saturated (deep tropical teal, golden-sand background, sunset coral, bold marigold) so it no longer reads like Spring; stays teal-primary so it's distinct from Autumn too.
- **Web Places key setup**: `docs/WEB_SETUP.md` (web-restricted key, GitHub secret, CORS caveat) + inject `GOOGLE_PLACES_API_KEY` into the web build via `--dart-define`. Web still needs the `GOOGLE_PLACES_API_KEY` secret added in repo settings to actually return data.

Analyzer clean, `dart format` clean, 333 tests pass.