### PR TITLE
fix(screenshots): make the fastlane screenshots lane pass; guard home setState

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -113,7 +113,6 @@
     "upsells",
     "URI",
     "valuekey",
-    "vendorbliss",
     "verygoodopensource",
     "Werror",
     "Wextra"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -68,7 +68,10 @@ platform :ios do
 
   desc "Generate App Store screenshots via integration tests on iOS simulators"
   lane :screenshots do
-    sh("mkdir -p fastlane/screenshots/en-US")
+    # Absolute dest (anchored to this Fastfile) so copies don't depend on the
+    # working directory fastlane/Ruby happen to be in.
+    dest_dir = File.join(__dir__, "screenshots", "en-US")
+    FileUtils.mkdir_p(dest_dir)
 
     target = "integration_test/screenshot_test.dart"
     tmp_dir = "/tmp/flutter_screenshots"
@@ -86,7 +89,7 @@ platform :ios do
 
     Dir.glob("#{tmp_dir}/*.png").each do |src|
       name = File.basename(src, ".png")
-      FileUtils.cp(src, "../fastlane/screenshots/en-US/#{name}_iphone.png")
+      FileUtils.cp(src, File.join(dest_dir, "#{name}_iphone.png"))
     end
 
     # --- iPad ---
@@ -102,7 +105,7 @@ platform :ios do
 
     Dir.glob("#{tmp_dir}/*.png").each do |src|
       name = File.basename(src, ".png")
-      FileUtils.cp(src, "../fastlane/screenshots/en-US/#{name}_ipad.png")
+      FileUtils.cp(src, File.join(dest_dir, "#{name}_ipad.png"))
     end
 
     UI.success("Screenshots generated in fastlane/screenshots/en-US/")

--- a/integration_test/helpers/mock_providers.dart
+++ b/integration_test/helpers/mock_providers.dart
@@ -48,6 +48,15 @@ const List<Restaurant> sampleRestaurants = [
     types: ['restaurant', 'mexican_restaurant'],
     isOpen: true,
     totalRatings: 342,
+    weekdayHours: [
+      'Monday: 11:00 AM – 9:00 PM',
+      'Tuesday: 11:00 AM – 9:00 PM',
+      'Wednesday: 11:00 AM – 9:00 PM',
+      'Thursday: 11:00 AM – 10:00 PM',
+      'Friday: 11:00 AM – 11:00 PM',
+      'Saturday: 10:00 AM – 11:00 PM',
+      'Sunday: 10:00 AM – 9:00 PM',
+    ],
   ),
   Restaurant(
     placeId: '4',

--- a/integration_test/screenshot_test.dart
+++ b/integration_test/screenshot_test.dart
@@ -9,16 +9,19 @@ import 'package:integration_test/integration_test.dart';
 import 'package:randoeats/blocs/blocs.dart';
 import 'package:randoeats/config/config.dart';
 import 'package:randoeats/screens/screens.dart';
+import 'package:randoeats/services/services.dart';
 
 import 'helpers/mock_providers.dart';
 
 late Directory _screenshotDir;
 
 void main() {
-  setUpAll(() {
+  setUpAll(() async {
     IntegrationTestWidgetsFlutterBinding.ensureInitialized();
     _screenshotDir = Directory('/tmp/flutter_screenshots')
       ..createSync(recursive: true);
+    // Detail/Settings read StorageService directly, so the boxes must exist.
+    await StorageService.instance.initialize();
   });
 
   // ==================== Warm-up ====================

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -43,6 +43,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     });
 
     final result = await LocationService.instance.getCurrentLocation();
+    if (!mounted) return;
 
     setState(() {
       _isLoading = false;


### PR DESCRIPTION
- **HomeScreen._checkLocation**: guard `mounted` before `setState` after the async location call (prevents a setState-after-dispose error; real bug fix).
- **Screenshot test**: initialize `StorageService` in `setUpAll` so Detail/Settings render (they read storage directly).
- **Fastfile**: copy screenshots to an absolute (`__dir__`-anchored) path — the relative path failed with ENOENT.
- **Mock data**: Taco Nebula now has weekday hours so the detail screenshot shows the hours UI.
- Remove stray `vendorbliss` from the cspell dictionary.

Analyzer clean, 333 tests pass.