### PR TITLE
feat: parking chip on detail, persistent spot count, hardened screenshots lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -73,6 +73,9 @@ platform :ios do
     dest_dir = File.join(__dir__, "screenshots", "en-US")
     FileUtils.mkdir_p(dest_dir)
 
+    # Bring the Simulator app up so booted devices register with the toolchain.
+    sh("open -a Simulator")
+
     target = "integration_test/screenshot_test.dart"
     tmp_dir = "/tmp/flutter_screenshots"
 
@@ -81,6 +84,9 @@ platform :ios do
     UI.message("Capturing iPhone screenshots on #{iphone_udid}...")
 
     sh("xcrun simctl boot #{iphone_udid} 2>/dev/null || true")
+    # Block until the device is fully booted — flutter test otherwise launches
+    # against a not-ready sim and hangs after the Xcode build.
+    sh("xcrun simctl bootstatus #{iphone_udid} -b")
     sh("rm -rf #{tmp_dir}")
     Dir.chdir("..") do
       sh("flutter test #{target} --flavor production -d #{iphone_udid}")
@@ -97,6 +103,7 @@ platform :ios do
     UI.message("Capturing iPad screenshots on #{ipad_udid}...")
 
     sh("xcrun simctl boot #{ipad_udid} 2>/dev/null || true")
+    sh("xcrun simctl bootstatus #{ipad_udid} -b")
     sh("rm -rf #{tmp_dir}")
     Dir.chdir("..") do
       sh("flutter test #{target} --flavor production -d #{ipad_udid}")

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -219,6 +219,16 @@ class DetailScreen extends ConsumerWidget {
                       : GoogieColors.onCoralContainer,
                   theme: theme,
                 ),
+              // Parking — shown when Google reports a parking option.
+              if (restaurant.hasParking ?? false)
+                _buildChip(
+                  icon: Icons.local_parking,
+                  iconColor: GoogieColors.onTurquoiseContainer,
+                  label: 'Parking',
+                  fill: GoogieColors.turquoiseContainer,
+                  textColor: GoogieColors.onTurquoiseContainer,
+                  theme: theme,
+                ),
             ],
           ),
           // Opening hours — today's line, tap to expand the whole week.

--- a/lib/screens/results/results_screen.dart
+++ b/lib/screens/results/results_screen.dart
@@ -492,8 +492,9 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
               onPressed: isSpinning ? null : _refreshRestaurants,
               tooltip: 'Find new restaurants',
             ),
-          // How many spots are in the reel right now.
-          if (canRefresh && count > 0)
+          // How many spots are in the reel right now — kept visible during a
+          // spin too (the refresh button hides then, the count shouldn't).
+          if (count > 0)
             Container(
               key: const ValueKey('result_count'),
               padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),


### PR DESCRIPTION
- **Parking chip** on the detail screen when Google reports a parking option (`Restaurant.hasParking`).
- **Spot count stays visible while spinning** (was tied to the refresh state, which is off during a spin).
- **Screenshots lane hardened**: open Simulator + wait for `simctl bootstatus -b` before running the test, so it no longer hangs after the Xcode build on a not-ready device.

Analyzer clean, 333 tests pass.