### PR TITLE
feat: version scheme (patch=build) + About page

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -47,25 +47,29 @@ jobs:
           VERSION_LINE=$(grep "^version:" pubspec.yaml)
           echo "Current: $VERSION_LINE"
 
-          # Extract version and build number
-          VERSION=$(echo $VERSION_LINE | sed 's/version: //' | cut -d'+' -f1)
+          # Keep major.minor; the patch tracks the build number so the version
+          # reads major.minor.<build> and increases by one on every push.
+          BASE=$(echo $VERSION_LINE | sed 's/version: //' | cut -d'+' -f1)
+          MAJOR_MINOR=$(echo $BASE | cut -d'.' -f1,2)
           CURRENT_BUILD=$(echo $VERSION_LINE | cut -d'+' -f2)
           NEW_BUILD=$((CURRENT_BUILD + 1))
+          NEW_VERSION="${MAJOR_MINOR}.${NEW_BUILD}+${NEW_BUILD}"
 
-          echo "Version: $VERSION, Build: $CURRENT_BUILD -> $NEW_BUILD"
+          echo "Version: $BASE -> $NEW_VERSION (build $CURRENT_BUILD -> $NEW_BUILD)"
 
           # Update pubspec.yaml
-          sed -i "s/^version: .*/version: ${VERSION}+${NEW_BUILD}/" pubspec.yaml
+          sed -i "s/^version: .*/version: ${NEW_VERSION}/" pubspec.yaml
 
           # Output for other jobs
           echo "build_number=$NEW_BUILD" >> $GITHUB_OUTPUT
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Commit build number
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add pubspec.yaml
-          git diff --staged --quiet || git commit -m "chore: bump build to ${{ steps.bump.outputs.build_number }} [skip ci]"
+          git diff --staged --quiet || git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
           git push
 
   # ============================================

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -20,6 +20,9 @@ abstract class AppRoutes {
 
   /// Region draw screen (create a new region).
   static const regionDraw = '/region/draw';
+
+  /// About screen.
+  static const about = '/about';
 }
 
 /// Provider for the app router.
@@ -56,6 +59,10 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: AppRoutes.regionDraw,
         builder: (context, state) => const RegionDrawScreen(),
+      ),
+      GoRoute(
+        path: AppRoutes.about,
+        builder: (context, state) => const AboutScreen(),
       ),
     ],
   );

--- a/lib/screens/about/about.dart
+++ b/lib/screens/about/about.dart
@@ -1,0 +1,4 @@
+/// About screen for rand-o-eats.
+library;
+
+export 'about_screen.dart';

--- a/lib/screens/about/about_screen.dart
+++ b/lib/screens/about/about_screen.dart
@@ -1,0 +1,167 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:randoeats/config/config.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// About screen — shows the app identity and the current version.
+///
+/// Reachable from the info button on the results screen.
+class AboutScreen extends StatefulWidget {
+  /// Creates an [AboutScreen].
+  const AboutScreen({super.key});
+
+  @override
+  State<AboutScreen> createState() => _AboutScreenState();
+}
+
+class _AboutScreenState extends State<AboutScreen> {
+  static const _website = 'https://randoeats.com';
+  static const _privacyUrl = 'https://tekadept.com/randoeats/privacy';
+  static const _termsUrl = 'https://tekadept.com/randoeats/terms';
+
+  String? _version;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_loadVersion());
+  }
+
+  Future<void> _loadVersion() async {
+    final info = await PackageInfo.fromPlatform();
+    if (!mounted) return;
+    // info.version is major.minor.patch (patch tracks the build number).
+    setState(() => _version = info.version);
+  }
+
+  Future<void> _open(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('About'),
+        leading: IconButton(
+          key: const ValueKey('about_back'),
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            children: [
+              const SizedBox(height: 16),
+              Image.asset(
+                'assets/images/rand-o-eats-new.png',
+                width: 160,
+                height: 160,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'rand-o-eats',
+                style: theme.textTheme.headlineMedium?.copyWith(
+                  color: GoogieColors.coral,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Your atomic-age appetite assistant',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                  fontStyle: FontStyle.italic,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                _version == null ? 'Version …' : 'Version $_version',
+                key: const ValueKey('about_version'),
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: GoogieColors.deepTeal,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 32),
+              _AboutLink(
+                icon: Icons.public,
+                label: 'randoeats.com',
+                onTap: () => unawaited(_open(_website)),
+                theme: theme,
+              ),
+              _AboutLink(
+                icon: Icons.privacy_tip_outlined,
+                label: 'Privacy Policy',
+                onTap: () => unawaited(_open(_privacyUrl)),
+                theme: theme,
+              ),
+              _AboutLink(
+                icon: Icons.description_outlined,
+                label: 'Terms of Service',
+                onTap: () => unawaited(_open(_termsUrl)),
+                theme: theme,
+              ),
+              const SizedBox(height: 32),
+              Text(
+                '© 2026 TekAdept',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AboutLink extends StatelessWidget {
+  const _AboutLink({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    required this.theme,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, size: 20, color: GoogieColors.turquoise),
+            const SizedBox(width: 10),
+            Text(
+              label,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: GoogieColors.turquoise,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/results/results_screen.dart
+++ b/lib/screens/results/results_screen.dart
@@ -520,6 +520,17 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
             onPressed: isSpinning ? null : _openQuickTune,
             tooltip: 'Quick tune',
           ),
+          // About (info) — sits between the filters tune and the gear.
+          IconButton(
+            key: const ValueKey('about_button'),
+            icon: const Icon(Icons.info_outline),
+            color: GoogieColors.deepTeal,
+            iconSize: 26,
+            onPressed: isSpinning
+                ? null
+                : () => unawaited(context.push<void>(AppRoutes.about)),
+            tooltip: 'About',
+          ),
           // Settings gear (right side)
           Semantics(
             identifier: 'settings_button',

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -1,6 +1,7 @@
 /// Screens for rand-o-eats.
 library;
 
+export 'about/about.dart';
 export 'detail/detail.dart';
 export 'home/home.dart';
 export 'region_draw/region_draw.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -765,7 +765,7 @@ packages:
     source: hosted
     version: "2.2.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus
       sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: randoeats
 description: Your atomic-age appetite assistant
-version: 1.0.0+74
+version: 1.0.74+74
 publish_to: none
 
 environment:
@@ -32,6 +32,7 @@ dependencies:
   in_app_purchase: ^3.3.0
   intl: ^0.20.2
   marionette_flutter: ^0.5.0
+  package_info_plus: ^8.1.2
   permission_handler: ^12.0.3
   url_launcher: ^6.3.1
 


### PR DESCRIPTION
## Versioning
Version now reads `major.minor.patch` where **patch = build number** (currently `1.0.74`), incrementing by one on every push. `distribute.yml` updated so the patch is set alongside the build number — store versionCode/build keeps increasing (it can't reset below 74).

## About page
New About page reachable from a new **ⓘ icon between the filters tune and the settings gear** on the results screen:
- Logo, "rand-o-eats", tagline
- **Version** read at runtime via `package_info_plus` (shows `1.0.74`)
- randoeats.com, Privacy Policy + Terms of Service (`tekadept.com/randoeats/...`), © 2026 TekAdept

Analyzer clean, 333 tests pass. Verified live on iOS (SF) and the Android emulator.