### PR TITLE
fix(deps): resolve package_info_plus conflict + bump crashlytics

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "8f89e371e2883de35cdc78f648e725fa4da5f3b6c927269f00fa68f1ea92b598"
+      sha256: "78f98c1f9c4dbbd22c2bb7b7f17c4a5c06150e8b2cb791a0947979ad0d3dabd5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.71"
+    version: "1.3.73"
   analyzer:
     dependency: transitive
     description:
@@ -269,18 +269,18 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_crashlytics
-      sha256: "9935ea36aaae0dfc789b80a1981fd70c6c7e9956791e9e7c2210ab83f9c963bd"
+      sha256: "2d9c791abef1cfd66c2572f5a4e172aa9f43476961af49742b1511dd327611df"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.2"
+    version: "5.2.4"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
-      sha256: ade20d7d86698ded596bf16ab0e7060ef1dae9258ab6705536a39ae047ccef59
+      sha256: cbedfe34081c4ad5c4e0558165383d4fa6b8fd70ae6e696190aad345adbb346c
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.22"
+    version: "3.8.24"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   equatable: ^2.0.7
   firebase_analytics: ^12.4.1
   firebase_core: ^4.11.0
-  firebase_crashlytics: ^5.2.2
+  firebase_crashlytics: ^5.2.4
   flutter:
     sdk: flutter
   flutter_localizations:
@@ -32,7 +32,7 @@ dependencies:
   in_app_purchase: ^3.3.0
   intl: ^0.20.2
   marionette_flutter: ^0.5.0
-  package_info_plus: ^8.1.2
+  package_info_plus: ^10.1.0
   permission_handler: ^12.0.3
   url_launcher: ^6.3.1
 


### PR DESCRIPTION
Fixes a dependency-resolution break on main: geolocator 14.0.3 (#41) transitively requires `package_info_plus ^10`, which conflicts with the `^8.1.2` pin added for the About page (#54) — `flutter pub get` was failing. Bumps `package_info_plus` to `^10.1.0` (the `PackageInfo.fromPlatform` API we use is unchanged) and folds in the Dependabot `firebase_crashlytics` 5.2.2 → 5.2.4 bump (#42).

Analyzer clean, 333 tests pass.