### PR TITLE
feat(detail): swipeable photo gallery

### DIFF
--- a/lib/models/restaurant.dart
+++ b/lib/models/restaurant.dart
@@ -17,6 +17,7 @@ class Restaurant extends Equatable {
     this.priceLevel,
     this.types = const [],
     this.photoReference,
+    this.photoReferences = const [],
     this.isOpen,
     this.totalRatings,
     this.servesBeer,
@@ -44,6 +45,7 @@ class Restaurant extends Equatable {
       priceLevel: _parsePriceLevelNew(json['priceLevel'] as String?),
       types: _parseTypes(json),
       photoReference: _extractPhotoName(photos),
+      photoReferences: _extractPhotoNames(photos),
       isOpen: openingHours?['openNow'] as bool?,
       totalRatings: json['userRatingCount'] as int?,
       servesBeer: json['servesBeer'] as bool?,
@@ -127,6 +129,11 @@ class Restaurant extends Equatable {
   @HiveField(16)
   final List<String>? weekdayHours;
 
+  /// All photo references for the place (Places `photos[].name`), in Google's
+  /// order, for the swipeable gallery. [photoReference] is the first of these.
+  @HiveField(17)
+  final List<String> photoReferences;
+
   /// Parses price level from new API enum string format.
   static String? _parsePriceLevelNew(String? level) {
     if (level == null) return null;
@@ -164,6 +171,16 @@ class Restaurant extends Equatable {
     return firstPhoto?['name'] as String?;
   }
 
+  /// Extracts all photo names (capped at 10) from the new API photos array.
+  static List<String> _extractPhotoNames(List<dynamic>? photos) {
+    if (photos == null) return const [];
+    return photos
+        .take(10)
+        .map((p) => (p as Map<String, dynamic>?)?['name'] as String?)
+        .whereType<String>()
+        .toList();
+  }
+
   /// Parses types from new API response.
   static List<String> _parseTypes(Map<String, dynamic> json) {
     // New API has primaryType and types array
@@ -197,6 +214,7 @@ class Restaurant extends Equatable {
     priceLevel,
     types,
     photoReference,
+    photoReferences,
     isOpen,
     totalRatings,
     servesBeer,

--- a/lib/models/restaurant.g.dart
+++ b/lib/models/restaurant.g.dart
@@ -31,13 +31,14 @@ class RestaurantAdapter extends TypeAdapter<Restaurant> {
       hasParking: fields[14] as bool?,
       phoneNumber: fields[15] as String?,
       weekdayHours: (fields[16] as List?)?.cast<String>(),
+      photoReferences: (fields[17] as List?)?.cast<String>() ?? const [],
     );
   }
 
   @override
   void write(BinaryWriter writer, Restaurant obj) {
     writer
-      ..writeByte(17)
+      ..writeByte(18)
       ..writeByte(0)
       ..write(obj.placeId)
       ..writeByte(1)
@@ -71,7 +72,9 @@ class RestaurantAdapter extends TypeAdapter<Restaurant> {
       ..writeByte(15)
       ..write(obj.phoneNumber)
       ..writeByte(16)
-      ..write(obj.weekdayHours);
+      ..write(obj.weekdayHours)
+      ..writeByte(17)
+      ..write(obj.photoReferences);
   }
 
   @override

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -74,10 +74,19 @@ class DetailScreen extends ConsumerWidget {
   }
 
   Widget _buildHeader(BuildContext context, ThemeData theme) {
-    final photoUrl = PlacesService.instance.getPhotoUrl(
-      restaurant.photoReference,
-      maxWidth: 800,
-    );
+    // Google returns the whole photos array, so build a URL for each and let
+    // the user swipe through them. Fall back to the single reference.
+    final urls = <String>[
+      for (final ref in restaurant.photoReferences)
+        ?PlacesService.instance.getPhotoUrl(ref, maxWidth: 800),
+    ];
+    if (urls.isEmpty) {
+      final single = PlacesService.instance.getPhotoUrl(
+        restaurant.photoReference,
+        maxWidth: 800,
+      );
+      if (single != null) urls.add(single);
+    }
 
     // Give the full-bleed photo more presence on wide screens, where a short
     // strip looked thin above the centered content column.
@@ -92,37 +101,9 @@ class DetailScreen extends ConsumerWidget {
         decoration: BoxDecoration(
           color: GoogieColors.turquoise.withValues(alpha: 0.2),
         ),
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            if (photoUrl != null)
-              Image.network(
-                photoUrl,
-                fit: BoxFit.cover,
-                width: double.infinity,
-                errorBuilder: (_, error, stackTrace) =>
-                    _buildPhotoPlaceholder(),
-                loadingBuilder: (context, child, loadingProgress) {
-                  if (loadingProgress == null) return child;
-                  return _buildPhotoPlaceholder(isLoading: true);
-                },
-              )
-            else
-              _buildPhotoPlaceholder(),
-            // Subtle bottom scrim so the photo transitions into the content
-            // instead of butting hard against it.
-            const DecoratedBox(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [Colors.transparent, Color(0x29000000)],
-                  stops: [0.65, 1],
-                ),
-              ),
-            ),
-          ],
-        ),
+        child: urls.isEmpty
+            ? _buildPhotoPlaceholder()
+            : _PhotoCarousel(photoUrls: urls),
       ),
     );
   }
@@ -810,6 +791,98 @@ class _ParkingChipState extends State<_ParkingChip> {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Swipeable photo gallery for the detail header, with page dots.
+class _PhotoCarousel extends StatefulWidget {
+  const _PhotoCarousel({required this.photoUrls});
+
+  final List<String> photoUrls;
+
+  @override
+  State<_PhotoCarousel> createState() => _PhotoCarouselState();
+}
+
+class _PhotoCarouselState extends State<_PhotoCarousel> {
+  final _controller = PageController();
+  int _index = 0;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Widget _placeholder({bool isLoading = false}) {
+    return Center(
+      child: isLoading
+          ? CircularProgressIndicator(color: GoogieColors.turquoise)
+          : Icon(Icons.restaurant, size: 80, color: GoogieColors.turquoise),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final urls = widget.photoUrls;
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        PageView.builder(
+          key: const ValueKey('detail_photo_carousel'),
+          controller: _controller,
+          itemCount: urls.length,
+          onPageChanged: (i) => setState(() => _index = i),
+          itemBuilder: (context, i) => Image.network(
+            urls[i],
+            fit: BoxFit.cover,
+            width: double.infinity,
+            errorBuilder: (_, _, _) => _placeholder(),
+            loadingBuilder: (context, child, progress) =>
+                progress == null ? child : _placeholder(isLoading: true),
+          ),
+        ),
+        // Subtle bottom scrim so the photo transitions into the content
+        // instead of butting hard against it.
+        const IgnorePointer(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [Colors.transparent, Color(0x29000000)],
+                stops: [0.65, 1],
+              ),
+            ),
+          ),
+        ),
+        // Page dots (only when there's more than one photo).
+        if (urls.length > 1)
+          Positioned(
+            bottom: 10,
+            left: 0,
+            right: 0,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                for (var i = 0; i < urls.length; i++)
+                  AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
+                    margin: const EdgeInsets.symmetric(horizontal: 3),
+                    width: i == _index ? 9 : 7,
+                    height: i == _index ? 9 : 7,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: GoogieColors.white.withValues(
+                        alpha: i == _index ? 1 : 0.5,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+      ],
     );
   }
 }

--- a/test/models/restaurant_test.dart
+++ b/test/models/restaurant_test.dart
@@ -46,6 +46,7 @@ void main() {
         r'$$',
         ['restaurant', 'cafe'],
         'photo_ref_123',
+        <String>[], // photoReferences
         true,
         100,
         null, // servesBeer


### PR DESCRIPTION
The `places.photos` field mask already returns the **whole** photos array — we only used `photos[0]`. Now parse all of them (capped at 10) into `Restaurant.photoReferences` and render the detail header as a **swipeable `PageView` with page dots**. No extra API cost (same field, more of the data we already pull). Falls back to the single photo / placeholder icon for 0–1 photos.

Verified on the iOS sim: detail shows ~10 dots, swiping advances the photo and updates the dot. Analyzer clean, 333 tests pass.