### PR TITLE
feat(detail): restaurant description below the photo

### DIFF
--- a/lib/models/restaurant.dart
+++ b/lib/models/restaurant.dart
@@ -26,6 +26,7 @@ class Restaurant extends Equatable {
     this.hasParking,
     this.phoneNumber,
     this.weekdayHours,
+    this.editorialSummary,
   });
 
   /// Creates a [Restaurant] from Places API (New) response.
@@ -56,6 +57,9 @@ class Restaurant extends Equatable {
       ),
       phoneNumber: json['nationalPhoneNumber'] as String?,
       weekdayHours: _parseWeekdayHours(openingHours),
+      editorialSummary:
+          (json['editorialSummary'] as Map<String, dynamic>?)?['text']
+              as String?,
     );
   }
 
@@ -133,6 +137,11 @@ class Restaurant extends Equatable {
   /// order, for the swipeable gallery. [photoReference] is the first of these.
   @HiveField(17)
   final List<String> photoReferences;
+
+  /// Short editorial description of the place from Places `editorialSummary`;
+  /// null when Google has none.
+  @HiveField(18)
+  final String? editorialSummary;
 
   /// Parses price level from new API enum string format.
   static String? _parsePriceLevelNew(String? level) {
@@ -223,5 +232,6 @@ class Restaurant extends Equatable {
     hasParking,
     phoneNumber,
     weekdayHours,
+    editorialSummary,
   ];
 }

--- a/lib/models/restaurant.g.dart
+++ b/lib/models/restaurant.g.dart
@@ -32,13 +32,14 @@ class RestaurantAdapter extends TypeAdapter<Restaurant> {
       phoneNumber: fields[15] as String?,
       weekdayHours: (fields[16] as List?)?.cast<String>(),
       photoReferences: (fields[17] as List?)?.cast<String>() ?? const [],
+      editorialSummary: fields[18] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, Restaurant obj) {
     writer
-      ..writeByte(18)
+      ..writeByte(19)
       ..writeByte(0)
       ..write(obj.placeId)
       ..writeByte(1)
@@ -74,7 +75,9 @@ class RestaurantAdapter extends TypeAdapter<Restaurant> {
       ..writeByte(16)
       ..write(obj.weekdayHours)
       ..writeByte(17)
-      ..write(obj.photoReferences);
+      ..write(obj.photoReferences)
+      ..writeByte(18)
+      ..write(obj.editorialSummary);
   }
 
   @override

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -47,6 +47,7 @@ class DetailScreen extends ConsumerWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
+                    _buildDescription(theme),
                     _buildInfo(context, theme),
                     Padding(
                       padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
@@ -119,6 +120,23 @@ class DetailScreen extends ConsumerWidget {
               size: 80,
               color: GoogieColors.turquoise,
             ),
+    );
+  }
+
+  Widget _buildDescription(ThemeData theme) {
+    final summary = restaurant.editorialSummary;
+    if (summary == null || summary.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      key: const ValueKey('detail_description'),
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+      child: Text(
+        summary,
+        style: theme.textTheme.bodyLarge?.copyWith(
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.85),
+          fontStyle: FontStyle.italic,
+          height: 1.35,
+        ),
+      ),
     );
   }
 

--- a/lib/services/places_service.dart
+++ b/lib/services/places_service.dart
@@ -54,7 +54,8 @@ class PlacesService {
       'places.photos,'
       'places.primaryType,'
       'places.nationalPhoneNumber,'
-      'places.currentOpeningHours';
+      'places.currentOpeningHours,'
+      'places.editorialSummary';
 
   /// Extra ("atmosphere") fields, requested only when an atmosphere filter is
   /// active — these push the request into Google's pricier SKU.

--- a/test/models/restaurant_test.dart
+++ b/test/models/restaurant_test.dart
@@ -55,6 +55,7 @@ void main() {
         null, // hasParking
         null, // phoneNumber
         null, // weekdayHours
+        null, // editorialSummary
       ]);
     });
 


### PR DESCRIPTION
Adds the Places `editorialSummary` (a short Google-written blurb) to the search field mask and shows it as an italic description **directly below the photo** on the detail screen. Hidden when Google has none.

**Cost:** `editorialSummary` is an Enterprise-tier field, and our search already requests Enterprise fields (hours/phone/rating), so this doesn't change the SKU/cost. It also arrives with the search, so no layout shift.

Verified live on the iOS sim (Heist Restaurant: "Snug, light-filled hangout featuring breakfast & lunch classics…"). Analyzer clean, 333 tests pass.