### PR TITLE
feat(filters): real atmosphere filtering + beer/wine

### DIFF
--- a/lib/models/restaurant.dart
+++ b/lib/models/restaurant.dart
@@ -21,6 +21,7 @@ class Restaurant extends Equatable {
     this.isOpen,
     this.totalRatings,
     this.servesBeer,
+    this.servesWine,
     this.outdoorSeating,
     this.goodForGroups,
     this.hasParking,
@@ -50,6 +51,7 @@ class Restaurant extends Equatable {
       isOpen: openingHours?['openNow'] as bool?,
       totalRatings: json['userRatingCount'] as int?,
       servesBeer: json['servesBeer'] as bool?,
+      servesWine: json['servesWine'] as bool?,
       outdoorSeating: json['outdoorSeating'] as bool?,
       goodForGroups: json['goodForGroups'] as bool?,
       hasParking: _parseParking(
@@ -110,6 +112,10 @@ class Restaurant extends Equatable {
   /// Serves beer — a Places "atmosphere" field (null = unknown).
   @HiveField(11)
   final bool? servesBeer;
+
+  /// Serves wine — a Places "atmosphere" field (null = unknown).
+  @HiveField(19)
+  final bool? servesWine;
 
   /// Whether the place has outdoor seating / a patio (null = unknown).
   @HiveField(12)
@@ -227,6 +233,7 @@ class Restaurant extends Equatable {
     isOpen,
     totalRatings,
     servesBeer,
+    servesWine,
     outdoorSeating,
     goodForGroups,
     hasParking,

--- a/lib/models/restaurant.g.dart
+++ b/lib/models/restaurant.g.dart
@@ -33,13 +33,14 @@ class RestaurantAdapter extends TypeAdapter<Restaurant> {
       weekdayHours: (fields[16] as List?)?.cast<String>(),
       photoReferences: (fields[17] as List?)?.cast<String>() ?? const [],
       editorialSummary: fields[18] as String?,
+      servesWine: fields[19] as bool?,
     );
   }
 
   @override
   void write(BinaryWriter writer, Restaurant obj) {
     writer
-      ..writeByte(19)
+      ..writeByte(20)
       ..writeByte(0)
       ..write(obj.placeId)
       ..writeByte(1)
@@ -77,7 +78,9 @@ class RestaurantAdapter extends TypeAdapter<Restaurant> {
       ..writeByte(17)
       ..write(obj.photoReferences)
       ..writeByte(18)
-      ..write(obj.editorialSummary);
+      ..write(obj.editorialSummary)
+      ..writeByte(19)
+      ..write(obj.servesWine);
   }
 
   @override

--- a/lib/models/spot_filters.dart
+++ b/lib/models/spot_filters.dart
@@ -15,6 +15,7 @@ class SpotFilters extends Equatable {
   const SpotFilters({
     this.cuisines = const {},
     this.servesBeer = false,
+    this.servesWine = false,
     this.outdoorSeating = false,
     this.goodForGroups = false,
     this.hasParking = false,
@@ -30,6 +31,10 @@ class SpotFilters extends Equatable {
   /// Only places that serve beer (atmosphere field).
   @HiveField(1)
   final bool servesBeer;
+
+  /// Only places that serve wine (atmosphere field).
+  @HiveField(8)
+  final bool servesWine;
 
   /// Only places with outdoor seating / a patio (atmosphere field).
   @HiveField(2)
@@ -59,6 +64,7 @@ class SpotFilters extends Equatable {
   bool get isEmpty =>
       cuisines.isEmpty &&
       !servesBeer &&
+      !servesWine &&
       !outdoorSeating &&
       !goodForGroups &&
       !hasParking &&
@@ -69,7 +75,7 @@ class SpotFilters extends Equatable {
   /// Whether any atmosphere filter is active (these need the pricier Places
   /// field mask — request those fields only when this is true).
   bool get usesAtmosphere =>
-      servesBeer || outdoorSeating || goodForGroups || hasParking;
+      servesBeer || servesWine || outdoorSeating || goodForGroups || hasParking;
 
   /// Display labels for known cuisine codes; unknown codes are title-cased.
   static const _cuisineLabels = <String, String>{
@@ -90,6 +96,7 @@ class SpotFilters extends Equatable {
         _cuisineLabels[c] ??
             (c.isEmpty ? c : '${c[0].toUpperCase()}${c.substring(1)}'),
       if (servesBeer) 'Beer',
+      if (servesWine) 'Wine',
       if (outdoorSeating) 'Patio',
       if (hasParking) 'Parking',
       if (goodForGroups) 'Group',
@@ -105,6 +112,7 @@ class SpotFilters extends Equatable {
     var n = 0;
     if (cuisines.isNotEmpty) n++;
     if (servesBeer) n++;
+    if (servesWine) n++;
     if (outdoorSeating) n++;
     if (goodForGroups) n++;
     if (hasParking) n++;
@@ -119,6 +127,7 @@ class SpotFilters extends Equatable {
   SpotFilters copyWith({
     Set<String>? cuisines,
     bool? servesBeer,
+    bool? servesWine,
     bool? outdoorSeating,
     bool? goodForGroups,
     bool? hasParking,
@@ -130,6 +139,7 @@ class SpotFilters extends Equatable {
     return SpotFilters(
       cuisines: cuisines ?? this.cuisines,
       servesBeer: servesBeer ?? this.servesBeer,
+      servesWine: servesWine ?? this.servesWine,
       outdoorSeating: outdoorSeating ?? this.outdoorSeating,
       goodForGroups: goodForGroups ?? this.goodForGroups,
       hasParking: hasParking ?? this.hasParking,
@@ -143,6 +153,7 @@ class SpotFilters extends Equatable {
   List<Object?> get props => [
     cuisines,
     servesBeer,
+    servesWine,
     outdoorSeating,
     goodForGroups,
     hasParking,

--- a/lib/models/spot_filters.g.dart
+++ b/lib/models/spot_filters.g.dart
@@ -22,13 +22,14 @@ class SpotFiltersAdapter extends TypeAdapter<SpotFilters> {
       openNow: fields[5] as bool? ?? false,
       minRating: fields[6] as double?,
       priceLevels: (fields[7] as List?)?.cast<int>().toSet() ?? const {},
+      servesWine: fields[8] as bool? ?? false,
     );
   }
 
   @override
   void write(BinaryWriter writer, SpotFilters obj) {
     writer
-      ..writeByte(8)
+      ..writeByte(9)
       ..writeByte(0)
       ..write(obj.cuisines.toList())
       ..writeByte(1)
@@ -44,7 +45,9 @@ class SpotFiltersAdapter extends TypeAdapter<SpotFilters> {
       ..writeByte(6)
       ..write(obj.minRating)
       ..writeByte(7)
-      ..write(obj.priceLevels.toList());
+      ..write(obj.priceLevels.toList())
+      ..writeByte(8)
+      ..write(obj.servesWine);
   }
 
   @override

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -237,11 +237,31 @@ class DetailScreen extends ConsumerWidget {
                       : GoogieColors.onCoralContainer,
                   theme: theme,
                 ),
-              // Parking — fetched per-detail-view (Place Details) so it shows
-              // even when the search didn't request the atmosphere fields.
-              _ParkingChip(
+              // Atmosphere chips — parking/beer/wine. Fetched per-detail-view
+              // (one Place Details call, shared) so they show even when the
+              // search didn't request the atmosphere fields.
+              _AtmosphereChip(
                 placeId: restaurant.placeId,
-                initialHasParking: restaurant.hasParking,
+                known: restaurant.hasParking,
+                select: (a) => a.hasParking,
+                icon: Icons.local_parking,
+                label: 'Parking',
+                theme: theme,
+              ),
+              _AtmosphereChip(
+                placeId: restaurant.placeId,
+                known: restaurant.servesBeer,
+                select: (a) => a.servesBeer,
+                icon: Icons.sports_bar,
+                label: 'Beer',
+                theme: theme,
+              ),
+              _AtmosphereChip(
+                placeId: restaurant.placeId,
+                known: restaurant.servesWine,
+                select: (a) => a.servesWine,
+                icon: Icons.wine_bar,
+                label: 'Wine',
                 theme: theme,
               ),
             ],
@@ -760,48 +780,41 @@ class _HoursSectionState extends State<_HoursSection> {
   }
 }
 
-/// Parking indicator. Shows a "Parking" chip when Google reports a parking
-/// option. If the search didn't already supply it, it fetches once per opened
-/// place (Place Details) so parking is shown on every detail page.
-class _ParkingChip extends StatefulWidget {
-  const _ParkingChip({
+/// One Place Details lookup per opened place for the atmosphere chips
+/// (parking/beer/wine), shared + cached by placeId so the chips fetch once.
+// ignore: specify_nonobvious_property_types
+final _atmosphereProvider = FutureProvider.family<PlaceAtmosphere, String>(
+  (ref, placeId) => PlacesService.instance.fetchAtmosphere(placeId),
+);
+
+/// An atmosphere indicator chip (parking/beer/wine). Uses the value from the
+/// search if present, otherwise the shared per-detail [_atmosphereProvider].
+/// Renders nothing unless Google confirms the amenity.
+class _AtmosphereChip extends ConsumerWidget {
+  const _AtmosphereChip({
     required this.placeId,
-    required this.initialHasParking,
+    required this.known,
+    required this.select,
+    required this.icon,
+    required this.label,
     required this.theme,
   });
 
   final String placeId;
-  final bool? initialHasParking;
+  final bool? known;
+  final bool? Function(PlaceAtmosphere) select;
+  final IconData icon;
+  final String label;
   final ThemeData theme;
 
   @override
-  State<_ParkingChip> createState() => _ParkingChipState();
-}
-
-class _ParkingChipState extends State<_ParkingChip> {
-  bool? _hasParking;
-
-  @override
-  void initState() {
-    super.initState();
-    _hasParking = widget.initialHasParking;
-    if (_hasParking == null) {
-      unawaited(_loadParking());
+  Widget build(BuildContext context, WidgetRef ref) {
+    var value = known;
+    if (value == null) {
+      final atmo = ref.watch(_atmosphereProvider(placeId)).asData?.value;
+      if (atmo != null) value = select(atmo);
     }
-  }
-
-  Future<void> _loadParking() async {
-    final result = await PlacesService.instance.fetchHasParking(
-      widget.placeId,
-    );
-    if (!mounted) return;
-    setState(() => _hasParking = result);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (_hasParking != true) return const SizedBox.shrink();
-    final theme = widget.theme;
+    if (value != true) return const SizedBox.shrink();
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
       decoration: BoxDecoration(
@@ -811,14 +824,10 @@ class _ParkingChipState extends State<_ParkingChip> {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(
-            Icons.local_parking,
-            size: 18,
-            color: GoogieColors.onTurquoiseContainer,
-          ),
+          Icon(icon, size: 18, color: GoogieColors.onTurquoiseContainer),
           const SizedBox(width: 6),
           Text(
-            'Parking',
+            label,
             style: theme.textTheme.bodyMedium?.copyWith(
               fontWeight: FontWeight.bold,
               color: GoogieColors.onTurquoiseContainer,

--- a/lib/services/places_service.dart
+++ b/lib/services/places_service.dart
@@ -1,6 +1,14 @@
 import 'package:dio/dio.dart';
 import 'package:randoeats/models/models.dart';
 
+/// Atmosphere flags fetched for a single place on its detail view. Each is
+/// true/false when Google reports it, or null when unknown.
+typedef PlaceAtmosphere = ({
+  bool? hasParking,
+  bool? servesBeer,
+  bool? servesWine,
+});
+
 /// Result types for Places API operations.
 sealed class PlacesResult {
   const PlacesResult();
@@ -61,6 +69,7 @@ class PlacesService {
   /// active — these push the request into Google's pricier SKU.
   static const _atmosphereFields =
       'places.servesBeer,'
+      'places.servesWine,'
       'places.outdoorSeating,'
       'places.goodForGroups,'
       'places.parkingOptions';
@@ -121,12 +130,29 @@ class PlacesService {
         filters: filters,
       );
 
-      // Filter out excluded places
-      final filtered = restaurants
-          .where((r) => !excludePlaceIds.contains(r.placeId))
-          .toList();
+      // Filter out excluded places, then apply the atmosphere facets
+      // client-side — the Places API can't filter these server-side, so we
+      // keep only places it confirms match (a null/unknown value is excluded).
+      var filtered = restaurants.where(
+        (r) => !excludePlaceIds.contains(r.placeId),
+      );
+      if (filters.servesBeer) {
+        filtered = filtered.where((r) => r.servesBeer ?? false);
+      }
+      if (filters.servesWine) {
+        filtered = filtered.where((r) => r.servesWine ?? false);
+      }
+      if (filters.outdoorSeating) {
+        filtered = filtered.where((r) => r.outdoorSeating ?? false);
+      }
+      if (filters.goodForGroups) {
+        filtered = filtered.where((r) => r.goodForGroups ?? false);
+      }
+      if (filters.hasParking) {
+        filtered = filtered.where((r) => r.hasParking ?? false);
+      }
 
-      return PlacesSuccess(filtered);
+      return PlacesSuccess(filtered.toList());
     } on Exception catch (e) {
       return PlacesError('Failed to fetch restaurants: $e');
     }
@@ -206,29 +232,34 @@ class PlacesService {
         : results;
   }
 
-  /// Fetches parking availability for a single place (Place Details, New).
+  /// Fetches atmosphere flags (parking, beer, wine) for a single place via
+  /// Place Details (New).
   ///
-  /// Called from the detail screen so the parking chip can appear even when the
-  /// search didn't request the (pricier) atmosphere fields — this is one cheap
-  /// lookup per opened place rather than atmosphere fields on every result.
-  /// Returns true/false when Google reports parking, or null if unknown/error.
-  Future<bool?> fetchHasParking(String placeId) async {
-    if (placeId.isEmpty || _apiKey.isEmpty) return null;
+  /// Called from the detail screen so those chips appear even when the search
+  /// didn't request the (pricier) atmosphere fields — one cheap lookup per
+  /// opened place rather than atmosphere fields on every result.
+  Future<PlaceAtmosphere> fetchAtmosphere(String placeId) async {
+    const empty = (hasParking: null, servesBeer: null, servesWine: null);
+    if (placeId.isEmpty || _apiKey.isEmpty) return empty;
     try {
       final response = await _client.get<Map<String, dynamic>>(
         '$_baseUrl/places/$placeId',
         options: Options(
           headers: {
             'X-Goog-Api-Key': _apiKey,
-            'X-Goog-FieldMask': 'parkingOptions',
+            'X-Goog-FieldMask': 'parkingOptions,servesBeer,servesWine',
           },
         ),
       );
-      final parking = response.data?['parkingOptions'] as Map<String, dynamic>?;
-      if (parking == null) return null;
-      return parking.values.any((v) => v == true);
+      final data = response.data;
+      final parking = data?['parkingOptions'] as Map<String, dynamic>?;
+      return (
+        hasParking: parking?.values.any((v) => v == true),
+        servesBeer: data?['servesBeer'] as bool?,
+        servesWine: data?['servesWine'] as bool?,
+      );
     } on DioException {
-      return null;
+      return empty;
     }
   }
 

--- a/lib/widgets/filter_chip_bar.dart
+++ b/lib/widgets/filter_chip_bar.dart
@@ -60,6 +60,15 @@ class FilterChipBar extends ConsumerWidget {
                     ),
                   ),
                   _FacetChip(
+                    key: const ValueKey('filter_wine'),
+                    label: 'Wine',
+                    icon: Icons.wine_bar,
+                    selected: filters.servesWine,
+                    onToggle: () => notifier.update(
+                      (f) => f.copyWith(servesWine: !f.servesWine),
+                    ),
+                  ),
+                  _FacetChip(
                     key: const ValueKey('filter_patio'),
                     label: 'Patio',
                     icon: Icons.deck,

--- a/test/models/restaurant_test.dart
+++ b/test/models/restaurant_test.dart
@@ -50,6 +50,7 @@ void main() {
         true,
         100,
         null, // servesBeer
+        null, // servesWine
         null, // outdoorSeating
         null, // goodForGroups
         null, // hasParking


### PR DESCRIPTION
**Beer Friday, delivered.** Two things:

1. **Atmosphere filters now actually filter.** Beer/Patio/Parking/Group previously only *fetched* the field — results weren't narrowed (Places can't filter these server-side). Now applied **client-side**, so selecting **Beer** keeps only beer-serving places (verified: 37 → 28 spots).
2. **Wine** added as a new facet (model, filter chip, search) — filterable just like Beer.

Also on the **detail screen**, show **🅿 Parking · 🍺 Beer · 🍷 Wine** chips, all from one shared per-view Place Details lookup (`PlaceAtmosphere`) — no extra calls.

Verified on the Android emulator: Beer filter narrows the list; Chao Pescao detail shows all three chips. Analyzer clean, 333 tests pass.