### PR TITLE
feat(bff): C++/Drogon Backend-for-Frontend

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -23,9 +23,22 @@
     "**/Pods/**",
     "lib/l10n/gen/",
     "**/*.g.dart",
-    "**/*.freezed.dart"
+    "**/*.freezed.dart",
+    "RANDOEATS_PROJECT.md"
   ],
   "words": [
+    "Drogon",
+    "drogon",
+    "jsoncpp",
+    "trantor",
+    "Nanode",
+    "Linode",
+    "googleusercontent",
+    "buildx",
+    "nproc",
+    "logrotate",
+    "copytruncate",
+    "systemd",
     "appbundle",
     "appname",
     "Appfile",

--- a/RANDOEATS_PROJECT.md
+++ b/RANDOEATS_PROJECT.md
@@ -1,0 +1,514 @@
+# RandoEats — Project Reference
+
+> Consolidated reference covering all conversations from concept through BFF spec.  
+> Last updated: June 25, 2026
+
+---
+
+## Table of Contents
+
+1. [Concept & Problem Statement](#1-concept--problem-statement)
+2. [App Identity & Branding](#2-app-identity--branding)
+3. [Tech Stack Overview](#3-tech-stack-overview)
+4. [Data Source Decision](#4-data-source-decision)
+5. [API Cost Model](#5-api-cost-model)
+6. [Architecture: Why a BFF?](#6-architecture-why-a-bff)
+7. [BFF: Endpoints](#7-bff-endpoints)
+8. [BFF: Field Masks & SKU Tiers](#8-bff-field-masks--sku-tiers)
+9. [BFF: Response Shape (Normalized Contract)](#9-bff-response-shape-normalized-contract)
+10. [BFF: Caching Strategy](#10-bff-caching-strategy)
+11. [BFF: Performance Metrics Logging](#11-bff-performance-metrics-logging)
+12. [BFF: Project Structure](#12-bff-project-structure)
+13. [BFF: Deployment Target](#13-bff-deployment-target)
+14. [Flutter Client: Caching Strategy](#14-flutter-client-caching-strategy)
+15. [Flutter Client: Location Services](#15-flutter-client-location-services)
+16. [Flutter Client: Map Library Decision](#16-flutter-client-map-library-decision)
+17. [Planned Features & Bugs (Backlog)](#17-planned-features--bugs-backlog)
+18. [Open Decisions (Pre-Build Blockers)](#18-open-decisions-pre-build-blockers)
+19. [Pipeline & CI/CD](#19-pipeline--cicd)
+20. [Housekeeping Notes](#20-housekeeping-notes)
+
+---
+
+## 1. Concept & Problem Statement
+
+RandoEats solves a single, specific problem: **where to eat when your group can't decide.**
+
+Two (or more) people want to go out but have no specific restaurant in mind. They open RandoEats, it finds well-rated local restaurants, factors in where they've been recently, and surfaces suggestions. The app is intended to be fun — colorful, animated, full of sound effects, with a strong retro-futuristic personality.
+
+**Core features:**
+- Nearby restaurant discovery using the device's current location
+- Filters by rating, price level, and cuisine type
+- Memory of recently visited places (avoid repetition)
+- Group preference support (eventual goal)
+- "Surprise me" instant pick button
+- AdMob ads (for learning and experimentation, not revenue expectation)
+
+---
+
+## 2. App Identity & Branding
+
+**Aesthetic:** Groovy 60s / retro-futuristic / space-age  
+**Vibe:** Fun, spontaneous, optimistic — the "Googie" architecture of apps  
+**Tagline:** "Your space-age food finder that randomly selects local restaurants, turning every mealtime into a cosmic adventure."
+
+**UI personality:**
+- Lots of color, sound effects, and animation
+- Psychedelic spin animations on buttons
+- Swipe interactions with audio feedback
+- Possible animated mascot (peace-sign character)
+- "Far Out Eats" mode for adventurous suggestions
+- "Groovy Vibes" filter (ambient/chill restaurants)
+
+**cspell note:** Add `// cspell:ignore Randoeats randoeats` to the top of `README.md` to suppress spell-check CI failures on the app name.
+
+---
+
+## 3. Tech Stack Overview
+
+| Layer | Technology |
+|-------|-----------|
+| Mobile/Web client | Flutter (Dart) |
+| BFF (Backend For Frontend) | C++ / Drogon framework |
+| Hosting | Linode Nanode 1 GB |
+| Restaurant data | Google Places API (New) |
+| On-device JSON cache | Hive |
+| On-device photo cache | flutter_cache_manager |
+| Ads | Google AdMob |
+| CI/CD | GitHub Actions + Fastlane |
+| App distribution | TestFlight (iOS), Firebase App Distribution (Android dev), Play Store internal track |
+
+---
+
+## 4. Data Source Decision
+
+**Chosen: Google Places API (New)**  
+Not the legacy Google Places API — the new version uses different endpoints and a different billing model.
+
+**Why Google over Yelp:**
+- More generous free tier for small apps
+- Better global coverage
+- Field masks give you fine-grained cost control (you pay per field group, not per call)
+- Simpler integration with Flutter ecosystem
+- Yelp ended free access in 2024; paid tiers start at $7.99/1,000 calls
+
+**Why not the legacy Google Places API:**  
+Legacy cannot be enabled on new projects. The BFF targets Places API (New) exclusively — the endpoints, field names, and billing SKUs are completely different.
+
+---
+
+## 5. API Cost Model
+
+Google Places API (New) bills per field group (SKU tier), not per call. The field mask you send determines which tier you're charged at.
+
+**SKU tiers relevant to RandoEats:**
+
+| SKU Tier | Triggers | Free calls/month (Essentials) |
+|----------|----------|-------------------------------|
+| Basic | `id`, `name`, `formattedAddress`, `location` | 10,000 |
+| Pro | `currentOpeningHours`, `photos` | 5,000 |
+| Enterprise | `rating`, `userRatingCount`, `priceLevel` | 1,000 |
+| Enterprise + Atmosphere | `reviews`, `reviewSummary` | 1,000 |
+
+**Critical finding from spec work:** Including `rating`, `userRatingCount`, or `priceLevel` in your Nearby Search field mask bumps the entire call to the Enterprise SKU — not Pro as originally assumed. The reviews endpoint triggers the most expensive tier (Enterprise + Atmosphere).
+
+**Cost control decisions made:**
+- Reviews are a separate BFF endpoint (`GET /reviews/{place_id}`) so they don't inflate the cost of standard list/detail page loads
+- Field masks are the minimum needed per endpoint, documented with SKU tier in code comments
+- Photos are proxied by the BFF but not cached server-side (memory constraint on Nanode) — cached client-side instead
+- Set a billing budget alert and daily quota cap in Google Cloud Console **before going live**
+
+---
+
+## 6. Architecture: Why a BFF?
+
+The Flutter app originally called Google Places directly. This is a problem for three reasons:
+
+1. **API key exposure.** The key would be in the compiled app binary, extractable by anyone who decompiles it. They could rack up charges on your account.
+2. **No shared caching.** Every user's search hits Google even if someone nearby just searched the same area. You pay per SKU call.
+3. **Client complexity.** The app has to handle normalization, error mapping, and Google's raw JSON shape. Swapping providers later means touching the app.
+
+**The BFF pattern:** A server-side proxy layer built specifically for one client (the Flutter app). It speaks the exact language the app needs — pre-shaped, stable response contracts. The app calls your BFF; your BFF calls Google. Google is never touched directly by the client.
+
+```
+Flutter App  →  RandoEats BFF (Drogon/C++)  →  Google Places API (New)
+                     ↓
+               InMemoryCache (TTL-based)
+                     ↓
+               MetricsLogger (JSONL)
+```
+
+**Architecture rule:** A single class — `GooglePlacesClient` — is the **only** component permitted to make upstream calls to Google. All other service and controller code goes through it. This is enforced by a §0 declaration in the spec (see BFF spec document) and makes the code auditable: one file to check for all outbound calls.
+
+---
+
+## 7. BFF Endpoints
+
+Base path: `/api/v1`. All responses JSON unless noted.
+
+| Method | Path | Maps to | Notes |
+|--------|------|---------|-------|
+| GET | `/api/v1/restaurants/nearby` | Places Nearby Search (POST upstream) | Params: `lat`, `lng`, `radius` (default 5000m, max 50000m), `type` (default `restaurant`), `max` (default 20) |
+| GET | `/api/v1/restaurants/{place_id}` | Places Details | Returns single normalized restaurant object. 404 if Google returns not-found. |
+| GET | `/api/v1/restaurants/{place_id}/photo` | Places Photo | Params: `photo_ref` (required), `max_width` (default 400, max 1600). Proxies image bytes, not JSON. |
+| GET | `/api/v1/restaurants/{place_id}/reviews` | Places Details (reviews fields only) | Separate endpoint to isolate Enterprise + Atmosphere SKU billing. |
+| GET | `/api/v1/health` | (none) | Returns `{"status":"ok","version":"..."}`. For Linode/uptime monitoring. |
+
+**Google upstream mapping:**
+
+| # | Purpose | HTTP Method | Google Path |
+|---|---------|------------|-------------|
+| 1 | Nearby Search | POST | `/v1/places:searchNearby` |
+| 2 | Place Details | GET | `/v1/places/{PLACE_ID}` |
+| 3 | Place Photo | GET | `/v1/{photoName}/media?maxWidthPx=...` |
+
+---
+
+## 8. BFF: Field Masks & SKU Tiers
+
+**Nearby Search field mask (list view — minimizes per-place cost):**
+```
+places.id,places.displayName,places.formattedAddress,places.location,
+places.rating,places.userRatingCount,places.priceLevel,places.primaryType,
+places.currentOpeningHours.openNow,places.photos
+```
+→ **Enterprise SKU** (due to `rating`, `userRatingCount`, `priceLevel`)
+
+**Place Details field mask (detail view):**
+```
+id,displayName,formattedAddress,location,rating,userRatingCount,priceLevel,
+primaryType,currentOpeningHours,nationalPhoneNumber,websiteUri,photos
+```
+→ **Enterprise SKU**
+
+**Reviews field mask (reviews endpoint only):**
+```
+reviews,reviewSummary
+```
+→ **Enterprise + Atmosphere SKU**
+
+Document the SKU tier in a code comment at every upstream call site. This is mandatory per the §0 declaration in the spec.
+
+---
+
+## 9. BFF: Response Shape (Normalized Contract)
+
+The client must never see raw Google JSON. All responses are normalized to a stable contract so Google can be swapped out later without touching the app.
+
+**Restaurant object (nearby list and detail view):**
+```json
+{
+  "id": "ChIJ...",
+  "name": "Some Diner",
+  "address": "123 Main St, Orange, CA",
+  "location": { "lat": 33.78, "lng": -117.85 },
+  "rating": 4.3,
+  "ratingCount": 812,
+  "priceLevel": 2,
+  "type": "restaurant",
+  "openNow": true,
+  "photoRefs": ["places/ChIJ.../photos/ATpl..."]
+}
+```
+
+**Reviews response:**
+```json
+{
+  "placeId": "ChIJ...",
+  "reviews": [
+    {
+      "author": "Jane D.",
+      "authorUri": "https://maps.google.com/...",
+      "rating": 5,
+      "text": "Amazing tacos.",
+      "publishTime": "2026-05-01T12:00:00Z",
+      "mapsUri": "https://maps.google.com/..."
+    }
+  ],
+  "reviewSummary": {
+    "text": "Reviewers love the tacos and friendly staff.",
+    "disclosureText": "Summarized with Gemini",
+    "reviewsUri": "https://maps.google.com/..."
+  }
+}
+```
+
+**Normalization rules:**
+- `reviewSummary` is omitted if Google did not return one (not guaranteed for all places)
+- Google's `priceLevel` enum (`PRICE_LEVEL_MODERATE` etc.) maps to int 0–4
+- `displayName.text` → `name`
+- Missing fields → omit or null, never crash
+- Nearby list response: `{ "restaurants": [ ... ] }`; detail view: bare object
+
+**Attribution requirement (mandatory per Google ToS):**  
+When `reviewSummary` is present, the Flutter UI **must** display `disclosureText` ("Summarized with Gemini") and a link from `reviewsUri`. This is not optional.
+
+---
+
+## 10. BFF: Caching Strategy
+
+The BFF uses an in-memory cache (`InMemoryCache`) behind an `ICache` interface. In-memory is appropriate for a single-instance Nanode at current scale. The interface allows swapping to Redis later without changing the service layer.
+
+**Cache is bounded** at 2,000 entries (configurable via `cache_max_entries` in `config.json`) with LRU-style eviction to prevent memory exhaustion on the 1 GB Nanode.
+
+**TTLs:**
+
+| Data | Server-side TTL | Rationale |
+|------|----------------|-----------|
+| Nearby search results | 1 hour | Restaurants don't open/close that fast |
+| Place details | 6 hours | Hours, ratings change slowly |
+| Reviews | 6 hours | Same as details |
+| Photos | Not cached server-side | Proxied directly; cached client-side |
+
+**Cache key scheme:**
+- Nearby: `nearby:{lat_rounded}:{lng_rounded}:{radius}:{type}`  
+  Round lat/lng to 3 decimal places (~110m precision) to maximize cache hits for searches in the same vicinity.
+- Details: `details:{place_id}`
+- Reviews: `reviews:{place_id}`
+- Photo: not cached (proxied bytes)
+
+**Google ToS constraint:** Google's platform terms restrict caching most Places content beyond 30 days. Place IDs are the exception (they can be cached indefinitely). All BFF TTLs sit far under 30 days. Do not "optimize" TTLs upward past that limit.
+
+**`Cache-Control` header:** The BFF returns a `Cache-Control` header on every response carrying the TTL value. This lets the Flutter client know the TTL without hardcoding it in the app.
+
+**Photo caching note:** In-memory photo byte caching was removed from the BFF spec due to memory constraints on the Nanode. Photos are proxied directly and cached on-device via `flutter_cache_manager` (see §14).
+
+---
+
+## 11. BFF: Performance Metrics Logging
+
+Metrics logging is a **first-class concern** — it establishes a Phase 0 baseline before caching is fully active, enabling objective before/after comparison.
+
+**Implementation:** A `MetricsFilter` Drogon filter wraps every request, measures timing, and writes a structured JSON Lines record to a log file after each response is sent.
+
+**Log schema (one JSON object per line):**
+```json
+{
+  "ts": "2026-06-25T10:30:00.123Z",
+  "method": "GET",
+  "path": "/api/v1/restaurants/nearby",
+  "status": 200,
+  "total_ms": 145,
+  "upstream_ms": 140,
+  "cache": "MISS",
+  "upstream_endpoint": "nearby_search"
+}
+```
+
+- `cache`: `HIT`, `MISS`, or `NONE` (endpoints with no cache, like `/health` or `/photo`)
+- `upstream_ms`: time spent waiting for Google (0 on cache HIT)
+- `total_ms`: full request-to-response time including serialization
+
+**Log path:** Configurable via `config.json`:
+```json
+"metrics_log_path": "/var/log/randoeats/metrics.jsonl"
+```
+
+**Log rotation** (`/etc/logrotate.d/randoeats`):
+
+```
+/var/log/randoeats/metrics.jsonl {
+    daily
+    rotate 30
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+    create 640 randoeats randoeats
+}
+```
+
+`copytruncate` is required because `MetricsLogger` holds the file open as a persistent `ofstream`. Standard logrotate (rename + new file) would leave the process writing to the renamed file. `copytruncate` copies then truncates the live file in place — brief theoretical window of 1–2 lost lines, acceptable for metrics.
+
+**Analysis tool:** `tools/analyze_metrics.py` — stdlib-only Python script that reads the JSONL log and computes latency percentiles (p50, p95, p99) and cache hit rates. Run before adding caching (Phase 0 baseline) and after (Phase 1+) to measure the actual improvement.
+
+---
+
+## 12. BFF: Project Structure
+
+```
+randoeats-bff/
+├── CMakeLists.txt
+├── config.json              # not committed — contains API key
+├── config.example.json      # committed — template with placeholder values
+├── .gitignore               # must include config.json
+├── README.md
+├── main.cc
+├── controllers/
+│   └── RestaurantController.{h,cc}
+├── services/
+│   ├── PlacesService.{h,cc}
+│   ├── GooglePlacesClient.{h,cc}   ← sole upstream choke point
+│   ├── ICache.h                    ← interface; swap in Redis later
+│   ├── InMemoryCache.{h,cc}
+│   └── MetricsLogger.{h,cc}
+├── filters/
+│   └── MetricsFilter.{h,cc}        ← Drogon pre/post filter for timing
+└── tools/
+    └── analyze_metrics.py
+```
+
+**Layer call rule:** Controller → Service → {GooglePlacesClient, CacheService}. Controllers never call GooglePlacesClient directly. This keeps the upstream logic in one place.
+
+---
+
+## 13. BFF: Deployment Target
+
+**Linode Nanode 1 GB**  
+$5/month · 1 vCPU · 1 GB RAM · 25 GB SSD
+
+This is a shared Linode that already runs VendorBliss and other TekAdept services.
+
+- Default port: **8848** (confirm this is free before deploying)
+- Run as a dedicated Linux service user (`randoeats` or similar — TBD)
+- Log directory: `/var/log/randoeats/` (create with correct ownership before first run)
+- Config file lives outside the repo; never committed
+
+---
+
+## 14. Flutter Client: Caching Strategy
+
+Two complementary cache layers — the BFF cache and on-device cache serve different purposes and both are needed.
+
+| | BFF Cache | On-device Cache |
+|--|-----------|-----------------|
+| Purpose | Reduces Google API calls / cost | Eliminates network round-trips / speed |
+| Scope | Shared across all users | Per device |
+| Tool | `InMemoryCache` (C++) | `hive` (JSON) + `flutter_cache_manager` (photos) |
+
+**On-device TTLs (intentionally shorter than BFF):**
+
+| Data | On-device TTL |
+|------|--------------|
+| Nearby results | 15 minutes |
+| Place details | 2 hours |
+| Photos | 7 days |
+
+**Photo caching:** `flutter_cache_manager` handles binary content to disk, respects TTL, handles re-validation. This is the biggest single win since photos are the most expensive bytes to re-fetch and the most static.
+
+**JSON caching:** A simple TTL wrapper around `hive`. Key scheme mirrors the BFF (rounded lat/lng for nearby, `place_id` for details).
+
+The BFF's `Cache-Control` header carries the TTL value so the client doesn't hardcode it.
+
+> **Status:** Designed, not yet implemented. Noted as a backlog item.
+
+---
+
+## 15. Flutter Client: Location Services
+
+Package: `geolocator`
+
+```dart
+Future<Position?> getUserLocation() async {
+  final permission = await Geolocator.requestPermission();
+  if (permission == LocationPermission.denied ||
+      permission == LocationPermission.deniedForever) {
+    return null; // handle gracefully in UI
+  }
+  return await Geolocator.getCurrentPosition(
+    desiredAccuracy: LocationAccuracy.medium,
+  );
+}
+```
+
+`LocationAccuracy.medium` is correct for a restaurant app — GPS-survey precision is unnecessary and high accuracy noticeably drains battery.
+
+---
+
+## 16. Flutter Client: Map Library Decision
+
+**⚠️ Open decision — must be made before Flutter client spec is written.**
+
+| | `google_maps_flutter` | `flutter_map` |
+|--|----------------------|---------------|
+| Tile source | Google Maps (separate billing SKU) | OpenStreetMap (free) |
+| API key required | Yes — separate Maps key | No |
+| Visual | Familiar Google Maps look | Configurable |
+| Vendor lock-in | Google | None |
+
+Since you're already using Google Places, Google Maps tiles give visual consistency and the key is already managed. But `flutter_map` + OSM keeps a second billing surface entirely off the table, which fits the TekAdept "no vendor lock-in" philosophy. This is a deliberate call — don't default to Google without deciding.
+
+---
+
+## 17. Planned Features & Bugs (Backlog)
+
+### Features
+
+**Reviews UI (designed, not built)**
+- Restaurant detail screen has two horizontally swipable lists stacked vertically
+- Good reviews (4+ stars) on top, critical reviews (under 4 stars) on bottom
+- Divider between them
+- Each list is a `PageView` — swipe left/right to move between cards
+- Animated dot indicators below each section label
+- Cards: author name, rating stars, review text (truncated ~4 lines), relative time
+- Color coded: green tint for good, red tint for critical
+- Empty state handled gracefully if one bucket has no reviews
+- `PageController` must be disposed to avoid memory leaks
+- Split threshold (`rating >= 4.0`) is configurable later
+
+**On-device caching** (designed, not built — see §14)
+
+**Group preference support** (eventual goal — not yet designed)
+
+**"Surprise me" button** (planned UX — not yet designed)
+
+### Bugs
+
+**Duplicate splash screen**  
+Two splash screens appear in sequence. Likely cause: Flutter's native splash (configured in `AndroidManifest.xml` / `LaunchScreen.storyboard`) plus a secondary Dart-side splash widget running on top.
+
+Resolution plan: Keep native splash only, remove Dart splash widget. If async init is needed (loading prefs, checking auth), hold the native splash using `flutter_native_splash` until ready, then go straight to home screen.
+
+---
+
+## 18. Open Decisions (Pre-Build Blockers)
+
+These must be resolved before handing the BFF spec to Claude Code:
+
+**Design decisions:**
+1. **Map library** — `google_maps_flutter` (Google Maps SKU, consistent look) vs `flutter_map` (OSM, free, no lock-in)
+2. **CORS allowed origins** — What is the RandoEats web domain? The BFF spec has a placeholder. Without a real value, Claude Code will default to something permissive or leave it blank.
+3. **Reviews scope** — Individual reviews only (up to 5), or individual reviews + Gemini AI summary? The summary requires mandatory attribution UI in Flutter (`disclosureText` + `reviewsUri` link). Confirm before building so normalization code is right the first time.
+
+**Google Cloud Console:**
+4. **Enable Places API (New)** — confirm it's enabled on your project, not the legacy version
+5. **Create a server-side API key** — restrict it by IP to the Linode's address; unrestricted keys are a liability
+6. **Set a billing budget alert and daily quota cap** — especially critical given the Enterprise + Atmosphere SKU the reviews endpoint triggers. Set before going live, not after the first surprise invoice.
+
+**Linode:**
+7. **Confirm port 8848 is free** — shared box with VendorBliss and other services
+8. **Create `/var/log/randoeats/`** with correct ownership before first run
+9. **Decide the Linux service user account** for the BFF process
+
+---
+
+## 19. Pipeline & CI/CD
+
+Initial pipeline design from early planning:
+
+**GitHub Actions workflows:**
+
+| Trigger | What runs |
+|---------|-----------|
+| Every push/PR | `flutter analyze`, `flutter test`, `flutter format` check |
+| Release tag | Build Android APK/AAB, build iOS IPA, build web, deploy web, upload to Play Store internal track, upload to TestFlight |
+
+**Tools in use:**
+- GitHub Actions (free tier)
+- Fastlane (iOS/Android automation)
+- Firebase App Distribution (dev/QA builds)
+- TestFlight (iOS beta)
+- Google Play Console internal track (Android)
+
+**analysis_options.yaml** — linting rules configured at project root.
+
+---
+
+## 20. Housekeeping Notes
+
+- **cspell:** Add `// cspell:ignore Randoeats randoeats` to the top of `README.md` to prevent CI spell-check failures
+- **API key in config.json:** Never commit `config.json`. It must be in `.gitignore`. The repo contains only `config.example.json` with placeholder values.
+- **Google ToS / caching limit:** Most Places content cannot be cached beyond 30 days per Google's platform terms. Place IDs are the exception. Do not increase cache TTLs past that threshold.
+- **Linode shared box:** The BFF shares a box with VendorBliss and other TekAdept services. Be mindful of port conflicts and memory. The `cache_max_entries` bound (default 2,000) exists specifically to prevent the BFF from crowding other services on the 1 GB Nanode.
+- **The BFF spec document** (`randoeats-bff-spec.md`) is the implementation handoff artifact for Claude Code. This project reference document is the human-readable history and decision log. Keep both.

--- a/bff/.dockerignore
+++ b/bff/.dockerignore
@@ -1,0 +1,5 @@
+build/
+config.json
+*.jsonl
+*.log
+.git

--- a/bff/.gitignore
+++ b/bff/.gitignore
@@ -1,0 +1,9 @@
+# Build output
+build/
+
+# Runtime config holds the API key — never commit it.
+config.json
+
+# Local logs
+*.log
+*.jsonl

--- a/bff/CMakeLists.txt
+++ b/bff/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+project(randoeats_bff CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Drogon brings in trantor + jsoncpp and enables C++20 coroutine support.
+find_package(Drogon CONFIG REQUIRED)
+
+add_executable(randoeats_bff
+  main.cc
+  controllers/RestaurantController.cc
+  services/GooglePlacesClient.cc
+  services/PlacesService.cc
+  services/InMemoryCache.cc
+  services/MetricsLogger.cc
+)
+
+target_include_directories(randoeats_bff PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(randoeats_bff PRIVATE Drogon::Drogon)

--- a/bff/Dockerfile
+++ b/bff/Dockerfile
@@ -1,0 +1,26 @@
+# RandoEats BFF — multi-stage build.
+#
+# The Linode is x86-64 while dev Macs are ARM, so always build for amd64:
+#   docker buildx build --platform linux/amd64 -t randoeats-bff:latest .
+#
+# Uses the official Drogon image (Drogon + deps prebuilt) so we don't recompile
+# the framework. config.json is never baked into the image — mount it at runtime.
+
+FROM drogonframework/drogon:latest AS build
+WORKDIR /src
+COPY CMakeLists.txt main.cc ./
+COPY controllers/ controllers/
+COPY services/ services/
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build -j"$(nproc)"
+
+FROM drogonframework/drogon:latest AS runtime
+WORKDIR /app
+COPY --from=build /src/build/randoeats_bff /app/randoeats_bff
+EXPOSE 8848
+# config.json (with the API key) and the log dir are mounted at runtime:
+#   docker run -d --name randoeats-bff -p 8848:8848 \
+#     -v /etc/randoeats/config.json:/app/config.json:ro \
+#     -v /var/log/randoeats:/var/log/randoeats \
+#     randoeats-bff:latest
+ENTRYPOINT ["/app/randoeats_bff", "/app/config.json"]

--- a/bff/README.md
+++ b/bff/README.md
@@ -1,0 +1,143 @@
+<!-- cspell:ignore Drogon drogon jsoncpp trantor Nanode Linode randoeats Randoeats googleusercontent buildx nproc logrotate copytruncate -->
+
+# RandoEats BFF
+
+A Backend-for-Frontend for the RandoEats Flutter app, written in **C++ / Drogon**.
+It is the only thing that talks to the Google Places API (New): the app calls the
+BFF, the BFF calls Google. This keeps the API key off the client, enables shared
+caching, and gives the app a stable, normalized response contract.
+
+> Full design rationale lives in [`../RANDOEATS_PROJECT.md`](../RANDOEATS_PROJECT.md).
+> Reviews are intentionally **not** implemented yet (cost) — there's a clean seam
+> to add a `/reviews` endpoint later.
+
+## Architecture (§0 rule)
+
+```
+Flutter App → RandoEats BFF (Drogon/C++) → Google Places API (New)
+                   │
+                   ├── InMemoryCache (TTL + LRU bounded)
+                   └── MetricsLogger (JSONL)
+```
+
+**`GooglePlacesClient` is the only component permitted to make upstream Google
+calls.** Controllers → Services → {`GooglePlacesClient`, `ICache`}. Every upstream
+call documents its billing SKU tier in a comment.
+
+## Endpoints (`/api/v1`)
+
+| Method | Path | Notes |
+|--------|------|-------|
+| GET | `/restaurants/nearby` | `lat`,`lng` (required), `radius` (m, default 5000, max 50000), `type` (default `restaurant`), `max` (default/clamped 20). → `{ "restaurants": [...] }` |
+| GET | `/restaurants/{place_id}` | Single normalized restaurant. 404 if not found. |
+| GET | `/restaurants/{place_id}/photo` | `photo_ref` (required), `max_width` (default 400, max 1600). Proxies image **bytes**. |
+| GET | `/health` | `{"status":"ok","version":"..."}` |
+
+Normalized restaurant: `id, name, address, location{lat,lng}, rating, ratingCount,
+priceLevel (0–4), type, openNow, phone, website, photoRefs[]` (missing fields omitted;
+`photoRefs` always present).
+
+## Configuration
+
+Copy the template and fill in the key (the real `config.json` is git-ignored —
+**never commit it**):
+
+```bash
+cp config.example.json config.json
+# edit config.json: set places_api_key
+```
+
+| Key | Meaning |
+|-----|---------|
+| `places_api_key` | Google Places API (New) key. **Restrict it by IP to the Linode.** |
+| `port` | Listen port (default 8848) |
+| `threads` | Drogon worker threads (1 is plenty on a Nanode) |
+| `cache_max_entries` | LRU bound (default 2000) — keeps RAM in check on the 1 GB box |
+| `nearby_ttl_seconds` / `details_ttl_seconds` | Cache TTLs (1h / 6h). Keep well under Google's 30-day caching limit. |
+| `metrics_log_path` | JSONL metrics file |
+| `allowed_origins` | CORS allow-list for the web client |
+
+## Build & run
+
+### Local (dev compile-check only)
+
+Apple Silicon Macs are ARM; the Linode is x86-64, so a local binary **won't run on
+the server** — local builds are just for fast compile-checking.
+
+```bash
+brew install drogon            # one-time
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+./build/randoeats_bff config.json
+```
+
+### Docker (the deployable x86-64 artifact)
+
+```bash
+docker buildx build --platform linux/amd64 -t randoeats-bff:latest .
+```
+
+**Run as a container** (mount config + log dir; nothing secret is baked in):
+
+```bash
+docker run -d --name randoeats-bff -p 8848:8848 \
+  -v /etc/randoeats/config.json:/app/config.json:ro \
+  -v /var/log/randoeats:/var/log/randoeats \
+  randoeats-bff:latest
+```
+
+**Or run the binary natively under systemd** (lighter on a shared 1 GB box —
+no Docker daemon). Extract the binary from the image, drop it at
+`/opt/randoeats/randoeats_bff`, and use a unit like:
+
+```ini
+[Unit]
+Description=RandoEats BFF
+After=network.target
+
+[Service]
+User=randoeats
+ExecStart=/opt/randoeats/randoeats_bff /etc/randoeats/config.json
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Logging & rotation
+
+`MetricsLogger` keeps the log file open, so logrotate must use `copytruncate`.
+`/etc/logrotate.d/randoeats`:
+
+```
+/var/log/randoeats/metrics.jsonl {
+    daily
+    rotate 30
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+    create 640 randoeats randoeats
+}
+```
+
+Create the dir first: `sudo mkdir -p /var/log/randoeats && sudo chown randoeats:randoeats /var/log/randoeats`.
+
+## Metrics analysis
+
+```bash
+python3 tools/analyze_metrics.py /var/log/randoeats/metrics.jsonl
+```
+
+Prints p50/p95/p99 latency and cache hit rate, overall and per upstream endpoint.
+Run before/after enabling caching to quantify the win.
+
+## Pre-deploy checklist
+
+- [ ] Places API **(New)** enabled in Google Cloud (not legacy)
+- [ ] Server key created and **IP-restricted to the Linode**
+- [ ] Billing budget alert + daily quota cap set
+- [ ] Port 8848 free on the Linode (shared box)
+- [ ] `/var/log/randoeats/` created with correct ownership
+- [ ] `config.json` placed outside the repo, not committed

--- a/bff/config.example.json
+++ b/bff/config.example.json
@@ -1,0 +1,14 @@
+{
+  "places_api_key": "YOUR_GOOGLE_PLACES_API_KEY",
+  "port": 8848,
+  "threads": 1,
+  "cache_max_entries": 2000,
+  "nearby_ttl_seconds": 3600,
+  "details_ttl_seconds": 21600,
+  "metrics_log_path": "/var/log/randoeats/metrics.jsonl",
+  "allowed_origins": [
+    "https://randoeats.com",
+    "https://www.randoeats.com",
+    "http://localhost:8080"
+  ]
+}

--- a/bff/controllers/RestaurantController.cc
+++ b/bff/controllers/RestaurantController.cc
@@ -1,0 +1,106 @@
+#include "RestaurantController.h"
+
+#include <algorithm>
+#include <string>
+
+#include "../services/AppContext.h"
+#include "../services/GooglePlacesClient.h"
+#include "../services/PlacesService.h"
+
+using drogon::HttpResponse;
+using drogon::HttpResponsePtr;
+
+namespace {
+
+// Stash metrics facts on the request for the post-handling advice in main.cc.
+void recordMetrics(const drogon::HttpRequestPtr& req, const std::string& cache,
+                   long upstreamMs, const std::string& endpoint) {
+  req->attributes()->insert("m_cache", cache);
+  req->attributes()->insert("m_upstream", static_cast<int64_t>(upstreamMs));
+  req->attributes()->insert("m_endpoint", endpoint);
+}
+
+HttpResponsePtr jsonResponse(const ServiceResult& result) {
+  auto resp = HttpResponse::newHttpResponse();
+  resp->setStatusCode(static_cast<drogon::HttpStatusCode>(result.status));
+  resp->setContentTypeCode(drogon::CT_APPLICATION_JSON);
+  resp->setBody(result.body);
+  if (result.ttlSeconds > 0) {
+    resp->addHeader("Cache-Control",
+                    "public, max-age=" + std::to_string(result.ttlSeconds));
+  }
+  return resp;
+}
+
+HttpResponsePtr errorResponse(int status, const std::string& message) {
+  auto resp = HttpResponse::newHttpResponse();
+  resp->setStatusCode(static_cast<drogon::HttpStatusCode>(status));
+  resp->setContentTypeCode(drogon::CT_APPLICATION_JSON);
+  resp->setBody("{\"error\":\"" + message + "\"}");
+  return resp;
+}
+
+}  // namespace
+
+drogon::Task<HttpResponsePtr> RestaurantController::nearby(
+    drogon::HttpRequestPtr req) {
+  const auto& params = req->getParameters();
+  if (!params.count("lat") || !params.count("lng")) {
+    recordMetrics(req, "NONE", 0, "");
+    co_return errorResponse(400, "lat and lng are required");
+  }
+
+  const double lat = std::stod(req->getParameter("lat"));
+  const double lng = std::stod(req->getParameter("lng"));
+  int radius =
+      params.count("radius") ? std::stoi(req->getParameter("radius")) : 5000;
+  radius = std::clamp(radius, 1, 50000);
+  std::string type =
+      params.count("type") ? req->getParameter("type") : "restaurant";
+  int maxResults =
+      params.count("max") ? std::stoi(req->getParameter("max")) : 20;
+  maxResults = std::clamp(maxResults, 1, 20);
+
+  const ServiceResult result = co_await AppContext::instance().places->nearby(
+      lat, lng, radius, std::move(type), maxResults);
+  recordMetrics(req, result.cache, result.upstreamMs, "nearby_search");
+  co_return jsonResponse(result);
+}
+
+drogon::Task<HttpResponsePtr> RestaurantController::details(
+    drogon::HttpRequestPtr req, std::string placeId) {
+  const ServiceResult result =
+      co_await AppContext::instance().places->details(placeId);
+  recordMetrics(req, result.cache, result.upstreamMs, "place_details");
+  co_return jsonResponse(result);
+}
+
+drogon::Task<HttpResponsePtr> RestaurantController::photo(
+    drogon::HttpRequestPtr req, std::string /*placeId*/) {
+  const auto& params = req->getParameters();
+  if (!params.count("photo_ref")) {
+    recordMetrics(req, "NONE", 0, "photo");
+    co_return errorResponse(400, "photo_ref is required");
+  }
+  const std::string photoRef = req->getParameter("photo_ref");
+  int maxWidth = params.count("max_width")
+                     ? std::stoi(req->getParameter("max_width"))
+                     : 400;
+  maxWidth = std::clamp(maxWidth, 1, 1600);
+
+  const PhotoResult photo =
+      co_await AppContext::instance().google->getPhoto(photoRef, maxWidth);
+  recordMetrics(req, "NONE", photo.upstreamMs, "photo");
+
+  if (photo.status != 200 || photo.bytes.empty()) {
+    co_return errorResponse(photo.status == 404 ? 404 : 502,
+                            "photo unavailable");
+  }
+
+  auto resp = HttpResponse::newHttpResponse();
+  resp->setStatusCode(drogon::k200OK);
+  resp->setContentTypeString(photo.contentType);
+  resp->setBody(photo.bytes);
+  resp->addHeader("Cache-Control", "public, max-age=604800");  // 7 days
+  co_return resp;
+}

--- a/bff/controllers/RestaurantController.h
+++ b/bff/controllers/RestaurantController.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <drogon/HttpController.h>
+
+#include <string>
+
+/// Maps the public `/api/v1/restaurants/...` routes to PlacesService. Controllers
+/// never call GooglePlacesClient directly — only PlacesService (and, for the raw
+/// photo bytes, the client via the same AppContext). See AppContext for wiring.
+class RestaurantController
+    : public drogon::HttpController<RestaurantController> {
+ public:
+  METHOD_LIST_BEGIN
+  ADD_METHOD_TO(RestaurantController::nearby, "/api/v1/restaurants/nearby",
+                drogon::Get);
+  // Photo route is registered before the catch-all {placeId} so it wins.
+  ADD_METHOD_TO(RestaurantController::photo,
+                "/api/v1/restaurants/{placeId}/photo", drogon::Get);
+  ADD_METHOD_TO(RestaurantController::details,
+                "/api/v1/restaurants/{placeId}", drogon::Get);
+  METHOD_LIST_END
+
+  drogon::Task<drogon::HttpResponsePtr> nearby(drogon::HttpRequestPtr req);
+  drogon::Task<drogon::HttpResponsePtr> details(drogon::HttpRequestPtr req,
+                                                std::string placeId);
+  drogon::Task<drogon::HttpResponsePtr> photo(drogon::HttpRequestPtr req,
+                                              std::string placeId);
+};

--- a/bff/main.cc
+++ b/bff/main.cc
@@ -1,0 +1,139 @@
+#include <drogon/drogon.h>
+#include <json/json.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <fstream>
+#include <memory>
+#include <string>
+
+#include "services/AppContext.h"
+#include "services/GooglePlacesClient.h"
+#include "services/InMemoryCache.h"
+#include "services/MetricsLogger.h"
+#include "services/PlacesService.h"
+
+using namespace drogon;
+
+namespace {
+
+int64_t nowNs() {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+/// Reflects the request Origin only if it's in the configured allow-list.
+void applyCors(const HttpRequestPtr& req, const HttpResponsePtr& resp) {
+  const std::string origin = req->getHeader("origin");
+  if (origin.empty()) return;
+  const auto& allowed = AppContext::instance().allowedOrigins;
+  if (std::find(allowed.begin(), allowed.end(), origin) != allowed.end()) {
+    resp->addHeader("Access-Control-Allow-Origin", origin);
+    resp->addHeader("Vary", "Origin");
+  }
+}
+
+Json::Value loadConfig(const std::string& path) {
+  std::ifstream in(path);
+  if (!in) {
+    LOG_FATAL << "Cannot open config file: " << path;
+    std::exit(1);
+  }
+  Json::Value cfg;
+  Json::CharReaderBuilder builder;
+  std::string errs;
+  if (!Json::parseFromStream(builder, in, &cfg, &errs)) {
+    LOG_FATAL << "Invalid config JSON: " << errs;
+    std::exit(1);
+  }
+  return cfg;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  const std::string configPath = argc > 1 ? argv[1] : "config.json";
+  const Json::Value cfg = loadConfig(configPath);
+
+  const std::string apiKey = cfg.get("places_api_key", "").asString();
+  if (apiKey.empty() || apiKey == "YOUR_GOOGLE_PLACES_API_KEY") {
+    LOG_FATAL << "places_api_key is not set in " << configPath;
+    return 1;
+  }
+  const int port = cfg.get("port", 8848).asInt();
+  const int threads = cfg.get("threads", 1).asInt();
+  const auto maxEntries =
+      static_cast<std::size_t>(cfg.get("cache_max_entries", 2000).asUInt());
+  const int nearbyTtl = cfg.get("nearby_ttl_seconds", 3600).asInt();
+  const int detailsTtl = cfg.get("details_ttl_seconds", 21600).asInt();
+  const std::string metricsPath =
+      cfg.get("metrics_log_path", "metrics.jsonl").asString();
+
+  auto& ctx = AppContext::instance();
+  ctx.metrics = std::make_shared<MetricsLogger>(metricsPath);
+  ctx.google = std::make_shared<GooglePlacesClient>(apiKey);
+  auto cache = std::make_shared<InMemoryCache>(maxEntries);
+  ctx.places = std::make_shared<PlacesService>(ctx.google, cache, nearbyTtl,
+                                               detailsTtl);
+  for (const auto& origin : cfg["allowed_origins"]) {
+    ctx.allowedOrigins.push_back(origin.asString());
+  }
+
+  // Health check (no cache, no upstream).
+  app().registerHandler(
+      "/api/v1/health",
+      [](const HttpRequestPtr&,
+         std::function<void(const HttpResponsePtr&)>&& callback) {
+        Json::Value body;
+        body["status"] = "ok";
+        body["version"] = "1.0.0";
+        callback(HttpResponse::newHttpJsonResponse(body));
+      },
+      {Get});
+
+  // CORS preflight: short-circuit OPTIONS before routing, otherwise Drogon
+  // rejects it as a disallowed method on the GET routes.
+  app().registerPreRoutingAdvice([](const HttpRequestPtr& req,
+                                    AdviceCallback&& stop,
+                                    AdviceChainCallback&& pass) {
+    if (req->method() == Options) {
+      auto resp = HttpResponse::newHttpResponse();
+      resp->setStatusCode(k204NoContent);
+      applyCors(req, resp);
+      resp->addHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+      resp->addHeader("Access-Control-Allow-Headers", "Content-Type");
+      resp->addHeader("Access-Control-Max-Age", "86400");
+      stop(resp);
+    } else {
+      pass();
+    }
+  });
+
+  // Metrics: stamp a start time before routing...
+  app().registerPreRoutingAdvice(
+      [](const HttpRequestPtr& req) { req->attributes()->insert("m_start", nowNs()); });
+
+  // ...and, after handling, apply CORS and write the JSONL metrics line.
+  app().registerPostHandlingAdvice(
+      [](const HttpRequestPtr& req, const HttpResponsePtr& resp) {
+        applyCors(req, resp);
+        const auto attrs = req->attributes();
+        const int64_t start = attrs->get<int64_t>("m_start");
+        const long total = start ? (nowNs() - start) / 1000000 : 0;
+        std::string cache = attrs->get<std::string>("m_cache");
+        if (cache.empty()) cache = "NONE";
+        const long upstream = static_cast<long>(attrs->get<int64_t>("m_upstream"));
+        const std::string endpoint = attrs->get<std::string>("m_endpoint");
+        AppContext::instance().metrics->log(
+            req->methodString(), req->path(),
+            static_cast<int>(resp->getStatusCode()), total, upstream, cache,
+            endpoint);
+      });
+
+  LOG_INFO << "RandoEats BFF listening on :" << port << " (" << threads
+           << " thread(s))";
+  app().addListener("0.0.0.0", port).setThreadNum(threads).run();
+  return 0;
+}

--- a/bff/services/AppContext.h
+++ b/bff/services/AppContext.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class PlacesService;
+class GooglePlacesClient;
+class MetricsLogger;
+
+/// Process-wide service container. Drogon constructs controllers as singletons
+/// with no constructor args, so dependencies are wired here in main() and read
+/// by controllers/advices. (shared_ptr supports the forward-declared types.)
+struct AppContext {
+  std::shared_ptr<PlacesService> places;
+  std::shared_ptr<GooglePlacesClient> google;
+  std::shared_ptr<MetricsLogger> metrics;
+  std::vector<std::string> allowedOrigins;
+
+  static AppContext& instance() {
+    static AppContext ctx;
+    return ctx;
+  }
+};

--- a/bff/services/GooglePlacesClient.cc
+++ b/bff/services/GooglePlacesClient.cc
@@ -1,0 +1,151 @@
+#include "GooglePlacesClient.h"
+
+#include <chrono>
+
+namespace {
+
+constexpr char kPlacesHost[] = "https://places.googleapis.com";
+
+// SKU: ENTERPRISE — rating/userRatingCount/priceLevel push the whole call to
+// the Enterprise tier. Keep this mask to the minimum the list view needs.
+constexpr char kNearbyMask[] =
+    "places.id,places.displayName,places.formattedAddress,places.location,"
+    "places.rating,places.userRatingCount,places.priceLevel,"
+    "places.primaryType,places.currentOpeningHours.openNow,places.photos";
+
+// SKU: ENTERPRISE — detail view.
+constexpr char kDetailsMask[] =
+    "id,displayName,formattedAddress,location,rating,userRatingCount,"
+    "priceLevel,primaryType,currentOpeningHours,nationalPhoneNumber,"
+    "websiteUri,photos";
+
+long elapsedMs(std::chrono::steady_clock::time_point start) {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now() - start)
+      .count();
+}
+
+}  // namespace
+
+GooglePlacesClient::GooglePlacesClient(std::string apiKey)
+    : apiKey_(std::move(apiKey)) {}
+
+drogon::Task<UpstreamResult> GooglePlacesClient::searchNearby(
+    double lat, double lng, int radius, std::string type, int maxResults) {
+  Json::Value body;
+  body["includedTypes"].append(type);
+  body["maxResultCount"] = maxResults;
+  auto& circle = body["locationRestriction"]["circle"];
+  circle["center"]["latitude"] = lat;
+  circle["center"]["longitude"] = lng;
+  circle["radius"] = static_cast<double>(radius);
+
+  Json::StreamWriterBuilder builder;
+  builder["indentation"] = "";
+
+  auto req = drogon::HttpRequest::newHttpRequest();
+  req->setMethod(drogon::Post);
+  req->setPath("/v1/places:searchNearby");
+  req->addHeader("X-Goog-Api-Key", apiKey_);
+  req->addHeader("X-Goog-FieldMask", kNearbyMask);
+  req->setContentTypeCode(drogon::CT_APPLICATION_JSON);
+  req->setBody(Json::writeString(builder, body));
+
+  UpstreamResult result;
+  const auto start = std::chrono::steady_clock::now();
+  try {
+    auto client = drogon::HttpClient::newHttpClient(kPlacesHost);
+    auto resp = co_await client->sendRequestCoro(req);
+    result.status = static_cast<int>(resp->getStatusCode());
+    if (auto json = resp->getJsonObject()) result.json = *json;
+  } catch (const std::exception& e) {
+    LOG_ERROR << "searchNearby upstream error: " << e.what();
+    result.status = 0;
+  }
+  result.upstreamMs = elapsedMs(start);
+  co_return result;
+}
+
+drogon::Task<UpstreamResult> GooglePlacesClient::getDetails(
+    std::string placeId) {
+  auto req = drogon::HttpRequest::newHttpRequest();
+  req->setMethod(drogon::Get);
+  req->setPath("/v1/places/" + placeId);
+  req->addHeader("X-Goog-Api-Key", apiKey_);
+  req->addHeader("X-Goog-FieldMask", kDetailsMask);
+
+  UpstreamResult result;
+  const auto start = std::chrono::steady_clock::now();
+  try {
+    auto client = drogon::HttpClient::newHttpClient(kPlacesHost);
+    auto resp = co_await client->sendRequestCoro(req);
+    result.status = static_cast<int>(resp->getStatusCode());
+    if (auto json = resp->getJsonObject()) result.json = *json;
+  } catch (const std::exception& e) {
+    LOG_ERROR << "getDetails upstream error: " << e.what();
+    result.status = 0;
+  }
+  result.upstreamMs = elapsedMs(start);
+  co_return result;
+}
+
+drogon::Task<PhotoResult> GooglePlacesClient::getPhoto(std::string photoName,
+                                                       int maxWidth) {
+  PhotoResult result;
+  const auto start = std::chrono::steady_clock::now();
+  try {
+    // Step 1: ask Google for the photo's CDN URL (skipHttpRedirect=true returns
+    // JSON {photoUri} instead of a 302). This is the billed PHOTO SKU call.
+    auto req = drogon::HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Get);
+    req->setPath("/v1/" + photoName + "/media");
+    req->setParameter("maxWidthPx", std::to_string(maxWidth));
+    req->setParameter("skipHttpRedirect", "true");
+    req->addHeader("X-Goog-Api-Key", apiKey_);
+
+    auto client = drogon::HttpClient::newHttpClient(kPlacesHost);
+    auto resp = co_await client->sendRequestCoro(req);
+    result.status = static_cast<int>(resp->getStatusCode());
+    if (result.status != 200) {
+      result.upstreamMs = elapsedMs(start);
+      co_return result;
+    }
+
+    std::string photoUri;
+    if (auto json = resp->getJsonObject()) {
+      photoUri = (*json)["photoUri"].asString();
+    }
+    if (photoUri.empty()) {
+      result.status = 502;
+      result.upstreamMs = elapsedMs(start);
+      co_return result;
+    }
+
+    // Step 2: fetch the actual image bytes from the (pre-signed) CDN URL. No
+    // API key needed; this hop isn't billed.
+    const auto schemeEnd = photoUri.find("://");
+    const auto hostStart = schemeEnd == std::string::npos ? 0 : schemeEnd + 3;
+    const auto pathStart = photoUri.find('/', hostStart);
+    const std::string origin = photoUri.substr(0, pathStart);
+    const std::string path =
+        pathStart == std::string::npos ? "/" : photoUri.substr(pathStart);
+
+    auto cdnReq = drogon::HttpRequest::newHttpRequest();
+    cdnReq->setMethod(drogon::Get);
+    cdnReq->setPath(path);
+    auto cdnClient = drogon::HttpClient::newHttpClient(origin);
+    auto cdnResp = co_await cdnClient->sendRequestCoro(cdnReq);
+    result.status = static_cast<int>(cdnResp->getStatusCode());
+    if (result.status == 200) {
+      const auto body = cdnResp->getBody();
+      result.bytes.assign(body.data(), body.size());
+      result.contentType = cdnResp->getHeader("content-type");
+      if (result.contentType.empty()) result.contentType = "image/jpeg";
+    }
+  } catch (const std::exception& e) {
+    LOG_ERROR << "getPhoto upstream error: " << e.what();
+    result.status = 0;
+  }
+  result.upstreamMs = elapsedMs(start);
+  co_return result;
+}

--- a/bff/services/GooglePlacesClient.h
+++ b/bff/services/GooglePlacesClient.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <drogon/drogon.h>
+#include <json/json.h>
+
+#include <string>
+
+/// Result of an upstream JSON call to Google.
+struct UpstreamResult {
+  int status = 0;       // HTTP status from Google; 0 = transport failure
+  Json::Value json;     // parsed response body (object), or null
+  long upstreamMs = 0;  // wall time spent on the Google call(s)
+};
+
+/// Result of an upstream photo (binary) fetch.
+struct PhotoResult {
+  int status = 0;
+  std::string bytes;
+  std::string contentType;
+  long upstreamMs = 0;
+};
+
+/// §0 — The ONLY component permitted to make upstream calls to Google Places
+/// (New). All controllers/services go through here, so every outbound call is
+/// auditable in one file. Each method documents the billing SKU tier it
+/// triggers via its field mask.
+class GooglePlacesClient {
+ public:
+  explicit GooglePlacesClient(std::string apiKey);
+
+  /// Nearby Search. SKU: ENTERPRISE (mask includes rating/userRatingCount/
+  /// priceLevel). Upstream: POST /v1/places:searchNearby.
+  drogon::Task<UpstreamResult> searchNearby(double lat, double lng, int radius,
+                                            std::string type, int maxResults);
+
+  /// Place Details. SKU: ENTERPRISE. Upstream: GET /v1/places/{placeId}.
+  drogon::Task<UpstreamResult> getDetails(std::string placeId);
+
+  /// Place Photo. SKU: PHOTO. Upstream: GET /v1/{photoName}/media, then the
+  /// returned googleusercontent URL for the bytes (proxied, not cached).
+  drogon::Task<PhotoResult> getPhoto(std::string photoName, int maxWidth);
+
+ private:
+  std::string apiKey_;
+};

--- a/bff/services/ICache.h
+++ b/bff/services/ICache.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+/// Cache abstraction so the service layer never depends on a concrete store.
+/// The current implementation is [InMemoryCache]; this interface exists so a
+/// Redis-backed cache can be dropped in later without touching PlacesService.
+///
+/// Values are pre-serialized, normalized JSON strings (what the client should
+/// receive), so a cache HIT can be returned verbatim with no re-parsing.
+class ICache {
+ public:
+  virtual ~ICache() = default;
+
+  /// Returns the cached value for [key], or nullopt if missing/expired.
+  virtual std::optional<std::string> get(const std::string& key) = 0;
+
+  /// Stores [value] under [key] for [ttlSeconds].
+  virtual void set(const std::string& key, const std::string& value,
+                   int ttlSeconds) = 0;
+};

--- a/bff/services/InMemoryCache.cc
+++ b/bff/services/InMemoryCache.cc
@@ -1,0 +1,53 @@
+#include "InMemoryCache.h"
+
+InMemoryCache::InMemoryCache(std::size_t maxEntries)
+    : maxEntries_(maxEntries == 0 ? 1 : maxEntries) {}
+
+std::optional<std::string> InMemoryCache::get(const std::string& key) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = map_.find(key);
+  if (it == map_.end()) return std::nullopt;
+
+  if (std::chrono::steady_clock::now() >= it->second.expiry) {
+    lru_.erase(it->second.lruIt);
+    map_.erase(it);
+    return std::nullopt;
+  }
+
+  touch(it->second, key);
+  return it->second.value;
+}
+
+void InMemoryCache::set(const std::string& key, const std::string& value,
+                        int ttlSeconds) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  const auto expiry = std::chrono::steady_clock::now() +
+                      std::chrono::seconds(ttlSeconds);
+
+  auto it = map_.find(key);
+  if (it != map_.end()) {
+    it->second.value = value;
+    it->second.expiry = expiry;
+    touch(it->second, key);
+    return;
+  }
+
+  lru_.push_front(key);
+  map_.emplace(key, Entry{value, expiry, lru_.begin()});
+  evictIfNeeded();
+}
+
+void InMemoryCache::touch(Entry& entry, const std::string& key) {
+  // Move this key to the front (most-recently-used) of the LRU list.
+  lru_.erase(entry.lruIt);
+  lru_.push_front(key);
+  entry.lruIt = lru_.begin();
+}
+
+void InMemoryCache::evictIfNeeded() {
+  while (map_.size() > maxEntries_ && !lru_.empty()) {
+    const std::string& oldest = lru_.back();
+    map_.erase(oldest);
+    lru_.pop_back();
+  }
+}

--- a/bff/services/InMemoryCache.h
+++ b/bff/services/InMemoryCache.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <list>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include "ICache.h"
+
+/// Thread-safe, TTL + LRU bounded in-memory cache.
+///
+/// Bounded at [maxEntries] (config `cache_max_entries`) with least-recently-used
+/// eviction so it can't exhaust memory on the 1 GB Nanode. Drogon serves
+/// requests on multiple threads, so every operation is guarded by a mutex.
+class InMemoryCache : public ICache {
+ public:
+  explicit InMemoryCache(std::size_t maxEntries);
+
+  std::optional<std::string> get(const std::string& key) override;
+  void set(const std::string& key, const std::string& value,
+           int ttlSeconds) override;
+
+ private:
+  struct Entry {
+    std::string value;
+    std::chrono::steady_clock::time_point expiry;
+    std::list<std::string>::iterator lruIt;  // position in lru_ (front = newest)
+  };
+
+  void touch(Entry& entry, const std::string& key);  // move key to LRU front
+  void evictIfNeeded();                               // assumes mutex held
+
+  std::size_t maxEntries_;
+  std::unordered_map<std::string, Entry> map_;
+  std::list<std::string> lru_;  // front = most recently used
+  std::mutex mutex_;
+};

--- a/bff/services/MetricsLogger.cc
+++ b/bff/services/MetricsLogger.cc
@@ -1,0 +1,55 @@
+#include "MetricsLogger.h"
+
+#include <json/json.h>
+
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+
+namespace {
+
+/// Current UTC time as ISO-8601 with millisecond precision, e.g.
+/// "2026-06-25T10:30:00.123Z".
+std::string isoNow() {
+  using namespace std::chrono;
+  const auto now = system_clock::now();
+  const auto ms = duration_cast<milliseconds>(now.time_since_epoch()) % 1000;
+  const std::time_t t = system_clock::to_time_t(now);
+  std::tm tm{};
+  gmtime_r(&t, &tm);
+  std::ostringstream os;
+  os << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S") << '.' << std::setfill('0')
+     << std::setw(3) << ms.count() << 'Z';
+  return os.str();
+}
+
+}  // namespace
+
+MetricsLogger::MetricsLogger(const std::string& path)
+    : out_(path, std::ios::app), enabled_(out_.is_open()) {}
+
+void MetricsLogger::log(const std::string& method, const std::string& path,
+                        int status, long totalMs, long upstreamMs,
+                        const std::string& cache,
+                        const std::string& upstreamEndpoint) {
+  if (!enabled_) return;
+
+  Json::Value rec;
+  rec["ts"] = isoNow();
+  rec["method"] = method;
+  rec["path"] = path;
+  rec["status"] = status;
+  rec["total_ms"] = static_cast<Json::Int64>(totalMs);
+  rec["upstream_ms"] = static_cast<Json::Int64>(upstreamMs);
+  rec["cache"] = cache;
+  rec["upstream_endpoint"] = upstreamEndpoint;
+
+  Json::StreamWriterBuilder builder;
+  builder["indentation"] = "";  // compact, single line
+  const std::string line = Json::writeString(builder, rec);
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  out_ << line << '\n';
+  out_.flush();
+}

--- a/bff/services/MetricsLogger.h
+++ b/bff/services/MetricsLogger.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <fstream>
+#include <mutex>
+#include <string>
+
+/// Appends one JSON object per line (JSON Lines) describing each request, for a
+/// Phase-0 latency/cache baseline and ongoing observability.
+///
+/// Holds the log file open as a persistent ofstream, so log rotation must use
+/// `copytruncate` (see /etc/logrotate.d/randoeats in the README). Thread-safe.
+class MetricsLogger {
+ public:
+  /// Opens [path] for appending. If it can't be opened, logging is disabled
+  /// (the BFF still serves traffic) rather than crashing.
+  explicit MetricsLogger(const std::string& path);
+
+  void log(const std::string& method, const std::string& path, int status,
+           long totalMs, long upstreamMs, const std::string& cache,
+           const std::string& upstreamEndpoint);
+
+ private:
+  std::ofstream out_;
+  std::mutex mutex_;
+  bool enabled_;
+};

--- a/bff/services/PlacesService.cc
+++ b/bff/services/PlacesService.cc
@@ -1,0 +1,150 @@
+#include "PlacesService.h"
+
+#include <array>
+#include <cstdio>
+
+namespace {
+
+std::string serializeCompact(const Json::Value& value) {
+  Json::StreamWriterBuilder builder;
+  builder["indentation"] = "";
+  return Json::writeString(builder, value);
+}
+
+int priceLevelToInt(const std::string& enumName) {
+  if (enumName == "PRICE_LEVEL_FREE") return 0;
+  if (enumName == "PRICE_LEVEL_INEXPENSIVE") return 1;
+  if (enumName == "PRICE_LEVEL_MODERATE") return 2;
+  if (enumName == "PRICE_LEVEL_EXPENSIVE") return 3;
+  if (enumName == "PRICE_LEVEL_VERY_EXPENSIVE") return 4;
+  return -1;  // unknown / absent
+}
+
+std::string errorBody(const std::string& message) {
+  Json::Value e;
+  e["error"] = message;
+  return serializeCompact(e);
+}
+
+}  // namespace
+
+PlacesService::PlacesService(std::shared_ptr<GooglePlacesClient> client,
+                             std::shared_ptr<ICache> cache, int nearbyTtl,
+                             int detailsTtl)
+    : client_(std::move(client)),
+      cache_(std::move(cache)),
+      nearbyTtl_(nearbyTtl),
+      detailsTtl_(detailsTtl) {}
+
+std::string PlacesService::serialize(const Json::Value& value) {
+  return serializeCompact(value);
+}
+
+Json::Value PlacesService::normalize(const Json::Value& place) {
+  Json::Value out;
+  out["id"] = place.get("id", "").asString();
+  if (place.isMember("displayName")) {
+    out["name"] = place["displayName"].get("text", "").asString();
+  }
+  if (place.isMember("formattedAddress")) {
+    out["address"] = place["formattedAddress"].asString();
+  }
+  if (place.isMember("location")) {
+    out["location"]["lat"] = place["location"].get("latitude", 0.0).asDouble();
+    out["location"]["lng"] = place["location"].get("longitude", 0.0).asDouble();
+  }
+  if (place.isMember("rating")) out["rating"] = place["rating"].asDouble();
+  if (place.isMember("userRatingCount")) {
+    out["ratingCount"] = place["userRatingCount"].asInt();
+  }
+  if (place.isMember("priceLevel")) {
+    const int level = priceLevelToInt(place["priceLevel"].asString());
+    if (level >= 0) out["priceLevel"] = level;
+  }
+  if (place.isMember("primaryType")) {
+    out["type"] = place["primaryType"].asString();
+  }
+  if (place.isMember("currentOpeningHours") &&
+      place["currentOpeningHours"].isMember("openNow")) {
+    out["openNow"] = place["currentOpeningHours"]["openNow"].asBool();
+  }
+  if (place.isMember("nationalPhoneNumber")) {
+    out["phone"] = place["nationalPhoneNumber"].asString();
+  }
+  if (place.isMember("websiteUri")) {
+    out["website"] = place["websiteUri"].asString();
+  }
+  // photoRefs is always present (possibly empty) so the client can rely on it.
+  out["photoRefs"] = Json::Value(Json::arrayValue);
+  if (place.isMember("photos")) {
+    for (const auto& photo : place["photos"]) {
+      out["photoRefs"].append(photo.get("name", "").asString());
+    }
+  }
+  return out;
+}
+
+drogon::Task<ServiceResult> PlacesService::nearby(double lat, double lng,
+                                                  int radius, std::string type,
+                                                  int maxResults) {
+  // Round lat/lng to ~110 m so nearby searches in the same vicinity share a
+  // cache entry.
+  std::array<char, 128> key{};
+  std::snprintf(key.data(), key.size(), "nearby:%.3f:%.3f:%d:%s", lat, lng,
+                radius, type.c_str());
+  const std::string cacheKey(key.data());
+
+  if (auto cached = cache_->get(cacheKey)) {
+    co_return ServiceResult{200, *cached, "HIT", 0, nearbyTtl_};
+  }
+
+  const UpstreamResult up =
+      co_await client_->searchNearby(lat, lng, radius, type, maxResults);
+
+  if (up.status == 0) {
+    co_return ServiceResult{502, errorBody("upstream unavailable"), "MISS",
+                            up.upstreamMs, 0};
+  }
+  if (up.status != 200) {
+    co_return ServiceResult{502, errorBody("upstream error"), "MISS",
+                            up.upstreamMs, 0};
+  }
+
+  Json::Value out;
+  out["restaurants"] = Json::Value(Json::arrayValue);
+  if (up.json.isMember("places")) {
+    for (const auto& place : up.json["places"]) {
+      out["restaurants"].append(normalize(place));
+    }
+  }
+  const std::string body = serialize(out);
+  cache_->set(cacheKey, body, nearbyTtl_);
+  co_return ServiceResult{200, body, "MISS", up.upstreamMs, nearbyTtl_};
+}
+
+drogon::Task<ServiceResult> PlacesService::details(std::string placeId) {
+  const std::string cacheKey = "details:" + placeId;
+
+  if (auto cached = cache_->get(cacheKey)) {
+    co_return ServiceResult{200, *cached, "HIT", 0, detailsTtl_};
+  }
+
+  const UpstreamResult up = co_await client_->getDetails(placeId);
+
+  if (up.status == 0) {
+    co_return ServiceResult{502, errorBody("upstream unavailable"), "MISS",
+                            up.upstreamMs, 0};
+  }
+  if (up.status == 404) {
+    co_return ServiceResult{404, errorBody("not found"), "MISS", up.upstreamMs,
+                            0};
+  }
+  if (up.status != 200) {
+    co_return ServiceResult{502, errorBody("upstream error"), "MISS",
+                            up.upstreamMs, 0};
+  }
+
+  const std::string body = serialize(normalize(up.json));
+  cache_->set(cacheKey, body, detailsTtl_);
+  co_return ServiceResult{200, body, "MISS", up.upstreamMs, detailsTtl_};
+}

--- a/bff/services/PlacesService.h
+++ b/bff/services/PlacesService.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <drogon/drogon.h>
+#include <json/json.h>
+
+#include <memory>
+#include <string>
+
+#include "GooglePlacesClient.h"
+#include "ICache.h"
+
+/// Outcome of a service call, carrying everything the controller needs to build
+/// the HTTP response and the metrics record.
+struct ServiceResult {
+  int status = 200;
+  std::string body;            // normalized JSON string (or {"error":...})
+  std::string cache = "MISS";  // HIT or MISS
+  long upstreamMs = 0;
+  int ttlSeconds = 0;          // for the Cache-Control header
+};
+
+/// Business logic: cache lookup, upstream fetch via GooglePlacesClient, and
+/// normalization to the stable client contract. Never returns raw Google JSON.
+class PlacesService {
+ public:
+  PlacesService(std::shared_ptr<GooglePlacesClient> client,
+                std::shared_ptr<ICache> cache, int nearbyTtl, int detailsTtl);
+
+  drogon::Task<ServiceResult> nearby(double lat, double lng, int radius,
+                                     std::string type, int maxResults);
+  drogon::Task<ServiceResult> details(std::string placeId);
+
+ private:
+  /// Maps one raw Google place to the normalized restaurant contract.
+  static Json::Value normalize(const Json::Value& place);
+  static std::string serialize(const Json::Value& value);
+
+  std::shared_ptr<GooglePlacesClient> client_;
+  std::shared_ptr<ICache> cache_;
+  int nearbyTtl_;
+  int detailsTtl_;
+};

--- a/bff/tools/analyze_metrics.py
+++ b/bff/tools/analyze_metrics.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Summarize the RandoEats BFF metrics log (JSON Lines).
+
+Computes latency percentiles (p50/p95/p99) and cache hit rates, overall and per
+upstream endpoint. Run it before enabling caching (Phase 0 baseline) and after
+to measure the real improvement.
+
+Usage:
+    python3 analyze_metrics.py /var/log/randoeats/metrics.jsonl
+    python3 analyze_metrics.py            # defaults to ./metrics.jsonl
+
+Stdlib only — no third-party dependencies.
+"""
+
+import json
+import sys
+from collections import defaultdict
+
+
+def percentile(values, pct):
+    """Nearest-rank percentile of a list of numbers."""
+    if not values:
+        return 0
+    ordered = sorted(values)
+    k = max(0, min(len(ordered) - 1, round((pct / 100) * len(ordered) + 0.5) - 1))
+    return ordered[k]
+
+
+def summarize(label, rows):
+    total = [r["total_ms"] for r in rows if "total_ms" in r]
+    upstream = [r["upstream_ms"] for r in rows if r.get("upstream_ms")]
+    caches = [r.get("cache", "NONE") for r in rows]
+    hits = caches.count("HIT")
+    cacheable = hits + caches.count("MISS")
+    hit_rate = (100 * hits / cacheable) if cacheable else 0.0
+
+    print(f"\n{label}  (n={len(rows)})")
+    print(f"  total_ms    p50={percentile(total, 50):>5}  "
+          f"p95={percentile(total, 95):>5}  p99={percentile(total, 99):>5}")
+    print(f"  upstream_ms p50={percentile(upstream, 50):>5}  "
+          f"p95={percentile(upstream, 95):>5}  p99={percentile(upstream, 99):>5}")
+    print(f"  cache       HIT={hits}  MISS={caches.count('MISS')}  "
+          f"NONE={caches.count('NONE')}  hit_rate={hit_rate:.1f}%")
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "metrics.jsonl"
+    rows = []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    rows.append(json.loads(line))
+    except FileNotFoundError:
+        print(f"No metrics file at {path}", file=sys.stderr)
+        return 1
+
+    if not rows:
+        print("No metrics records found.")
+        return 0
+
+    summarize("ALL", rows)
+
+    by_endpoint = defaultdict(list)
+    for r in rows:
+        by_endpoint[r.get("upstream_endpoint") or "(none)"].append(r)
+    for endpoint in sorted(by_endpoint):
+        summarize(f"endpoint: {endpoint}", by_endpoint[endpoint])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds `bff/` — a C++/Drogon BFF that is the **sole** component talking to Google Places (New). The app calls the BFF; the BFF calls Google. Keeps the API key server-side, enables shared caching, and gives the client a stable normalized contract.

**Endpoints** (`/api/v1`): `restaurants/nearby`, `restaurants/{id}`, `restaurants/{id}/photo` (proxies bytes), `/health`. Reviews intentionally deferred (cost).

**Design (per RANDOEATS_PROJECT.md):**
- `GooglePlacesClient` is the only upstream choke point (§0); every call documents its billing SKU tier.
- TTL + LRU bounded `InMemoryCache` behind `ICache` (swap to Redis later); rounded-latlng keys; `Cache-Control` header.
- `MetricsLogger` → JSONL; pre/post advices time every request; `tools/analyze_metrics.py` for p50/p95/p99 + hit rate.
- CORS allow-list; coroutine handlers.
- Multi-stage `Dockerfile` targeting **linux/amd64** (Linode is x86, dev Macs are ARM); `config.json` git-ignored, `config.example.json` committed.

**Verified locally** (cmake + Apple clang, Drogon 1.9.12): builds clean; `/health` 200, missing-params 400, upstream reached (502 w/ fake key), CORS preflight 204 + headers, JSONL metrics written. Build is Docker-agnostic; README documents both container and systemd run modes.