### PR TITLE
feat(bff): /nearby + /details parity with the Flutter client

### DIFF
--- a/bff/README.md
+++ b/bff/README.md
@@ -28,14 +28,16 @@ call documents its billing SKU tier in a comment.
 
 | Method | Path | Notes |
 |--------|------|-------|
-| GET | `/restaurants/nearby` | `lat`,`lng` (required), `radius` (m, default 5000, max 50000), `type` (default `restaurant`), `max` (default/clamped 20). → `{ "restaurants": [...] }` |
-| GET | `/restaurants/{place_id}` | Single normalized restaurant. 404 if not found. |
+| GET | `/restaurants/nearby` | **List view.** `lat`,`lng` (required); `q` (keyword/cuisine/mood; empty = browse); `radius` (m, default 5000, max 50000); `max` (default 20, max 60 — paginated); filters: `open=true`, `min_rating`, `price` (CSV of 1–4), and atmosphere `beer`/`wine`/`patio`/`group`/`parking` (`=true`). → `{ "restaurants": [...] }` |
+| GET | `/restaurants/{place_id}` | **Detail view** — single normalized restaurant with the full field set. 404 if not found. |
 | GET | `/restaurants/{place_id}/photo` | `photo_ref` (required), `max_width` (default 400, max 1600). Proxies image **bytes**. |
 | GET | `/health` | `{"status":"ok","version":"..."}` |
 
-Normalized restaurant: `id, name, address, location{lat,lng}, rating, ratingCount,
-priceLevel (0–4), type, openNow, phone, website, photoRefs[]` (missing fields omitted;
-`photoRefs` always present).
+**Normalization** (missing fields omitted; `photoRefs` always present):
+- **List** (`/nearby`, lean/Enterprise): `id, name, address, location{lat,lng}, rating, ratingCount, priceLevel (0–4), type, openNow, photoRefs[]`. Atmosphere fields are also fetched + returned **only when an atmosphere filter is active** (it's then filtered client-side, since Places can't filter these upstream).
+- **Detail** (`/{id}`, full/Enterprise+Atmosphere): the above **plus** `phone, website, weekdayHours[], editorialSummary, servesBeer, servesWine, outdoorSeating, goodForGroups, hasParking`.
+
+Server-side filters (`open`/`min_rating`/`price`) and pagination (up to ~60 via `nextPageToken`) are handled in the BFF, mirroring the Flutter client it replaces.
 
 ## Configuration
 

--- a/bff/controllers/RestaurantController.cc
+++ b/bff/controllers/RestaurantController.cc
@@ -1,6 +1,7 @@
 #include "RestaurantController.h"
 
 #include <algorithm>
+#include <sstream>
 #include <string>
 
 #include "../services/AppContext.h"
@@ -50,19 +51,38 @@ drogon::Task<HttpResponsePtr> RestaurantController::nearby(
     co_return errorResponse(400, "lat and lng are required");
   }
 
-  const double lat = std::stod(req->getParameter("lat"));
-  const double lng = std::stod(req->getParameter("lng"));
-  int radius =
-      params.count("radius") ? std::stoi(req->getParameter("radius")) : 5000;
-  radius = std::clamp(radius, 1, 50000);
-  std::string type =
-      params.count("type") ? req->getParameter("type") : "restaurant";
-  int maxResults =
-      params.count("max") ? std::stoi(req->getParameter("max")) : 20;
-  maxResults = std::clamp(maxResults, 1, 20);
+  const auto boolParam = [&](const char* name) {
+    return params.count(name) && req->getParameter(name) == "true";
+  };
 
-  const ServiceResult result = co_await AppContext::instance().places->nearby(
-      lat, lng, radius, std::move(type), maxResults);
+  NearbyQuery q;
+  q.lat = std::stod(req->getParameter("lat"));
+  q.lng = std::stod(req->getParameter("lng"));
+  q.radius = std::clamp(
+      params.count("radius") ? std::stoi(req->getParameter("radius")) : 5000, 1,
+      50000);
+  q.maxResults = std::clamp(
+      params.count("max") ? std::stoi(req->getParameter("max")) : 20, 1, 60);
+  if (params.count("q")) q.query = req->getParameter("q");
+  q.openNow = boolParam("open");
+  if (params.count("min_rating")) {
+    q.minRating = std::stod(req->getParameter("min_rating"));
+  }
+  if (params.count("price")) {  // CSV of 1..4, e.g. "1,2,3"
+    std::stringstream ss(req->getParameter("price"));
+    std::string tok;
+    while (std::getline(ss, tok, ',')) {
+      if (!tok.empty()) q.priceLevels.push_back(std::stoi(tok));
+    }
+  }
+  q.beer = boolParam("beer");
+  q.wine = boolParam("wine");
+  q.patio = boolParam("patio");
+  q.group = boolParam("group");
+  q.parking = boolParam("parking");
+
+  const ServiceResult result =
+      co_await AppContext::instance().places->nearby(std::move(q));
   recordMetrics(req, result.cache, result.upstreamMs, "nearby_search");
   co_return jsonResponse(result);
 }

--- a/bff/services/GooglePlacesClient.cc
+++ b/bff/services/GooglePlacesClient.cc
@@ -1,23 +1,31 @@
 #include "GooglePlacesClient.h"
 
+#include <algorithm>
 #include <chrono>
 
 namespace {
 
 constexpr char kPlacesHost[] = "https://places.googleapis.com";
 
-// SKU: ENTERPRISE — rating/userRatingCount/priceLevel push the whole call to
-// the Enterprise tier. Keep this mask to the minimum the list view needs.
+// SKU: ENTERPRISE — list view. rating/userRatingCount/priceLevel set the tier.
 constexpr char kNearbyMask[] =
     "places.id,places.displayName,places.formattedAddress,places.location,"
     "places.rating,places.userRatingCount,places.priceLevel,"
     "places.primaryType,places.currentOpeningHours.openNow,places.photos";
 
-// SKU: ENTERPRISE — detail view.
+// Added to the list mask only when an atmosphere filter is active. SKU bumps to
+// ENTERPRISE + ATMOSPHERE for that request.
+constexpr char kNearbyAtmosphereMask[] =
+    ",places.servesBeer,places.servesWine,places.outdoorSeating,"
+    "places.goodForGroups,places.parkingOptions";
+
+// SKU: ENTERPRISE + ATMOSPHERE — detail view (single place; fields are bare,
+// no "places." prefix).
 constexpr char kDetailsMask[] =
     "id,displayName,formattedAddress,location,rating,userRatingCount,"
     "priceLevel,primaryType,currentOpeningHours,nationalPhoneNumber,"
-    "websiteUri,photos";
+    "websiteUri,photos,editorialSummary,servesBeer,servesWine,outdoorSeating,"
+    "goodForGroups,parkingOptions";
 
 long elapsedMs(std::chrono::steady_clock::time_point start) {
   return std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -25,43 +33,100 @@ long elapsedMs(std::chrono::steady_clock::time_point start) {
       .count();
 }
 
+std::string priceLevelEnum(int level) {
+  switch (level) {
+    case 1: return "PRICE_LEVEL_INEXPENSIVE";
+    case 2: return "PRICE_LEVEL_MODERATE";
+    case 3: return "PRICE_LEVEL_EXPENSIVE";
+    case 4: return "PRICE_LEVEL_VERY_EXPENSIVE";
+    default: return "";
+  }
+}
+
 }  // namespace
 
 GooglePlacesClient::GooglePlacesClient(std::string apiKey)
     : apiKey_(std::move(apiKey)) {}
 
-drogon::Task<UpstreamResult> GooglePlacesClient::searchNearby(
-    double lat, double lng, int radius, std::string type, int maxResults) {
-  Json::Value body;
-  body["includedTypes"].append(type);
-  body["maxResultCount"] = maxResults;
-  auto& circle = body["locationRestriction"]["circle"];
-  circle["center"]["latitude"] = lat;
-  circle["center"]["longitude"] = lng;
-  circle["radius"] = static_cast<double>(radius);
+drogon::Task<UpstreamResult> GooglePlacesClient::searchText(SearchParams p) {
+  // Body shared across pages (must stay constant when a pageToken is supplied).
+  Json::Value base;
+  base["textQuery"] =
+      p.query.empty() ? "restaurant" : (p.query + " restaurant");
+  base["includedType"] = "restaurant";
+  auto& circle = base["locationBias"]["circle"];
+  circle["center"]["latitude"] = p.lat;
+  circle["center"]["longitude"] = p.lng;
+  circle["radius"] = static_cast<double>(p.radius);
+  if (p.openNow) base["openNow"] = true;
+  if (p.minRating > 0) base["minRating"] = p.minRating;
+  for (int level : p.priceLevels) {
+    const std::string e = priceLevelEnum(level);
+    if (!e.empty()) base["priceLevels"].append(e);
+  }
 
-  Json::StreamWriterBuilder builder;
-  builder["indentation"] = "";
+  std::string mask = kNearbyMask;
+  if (p.includeAtmosphere) mask += kNearbyAtmosphereMask;
+  mask += ",nextPageToken";
 
-  auto req = drogon::HttpRequest::newHttpRequest();
-  req->setMethod(drogon::Post);
-  req->setPath("/v1/places:searchNearby");
-  req->addHeader("X-Goog-Api-Key", apiKey_);
-  req->addHeader("X-Goog-FieldMask", kNearbyMask);
-  req->setContentTypeCode(drogon::CT_APPLICATION_JSON);
-  req->setBody(Json::writeString(builder, body));
+  const int pageSize = std::clamp(p.maxResults, 1, 20);
+  Json::StreamWriterBuilder writer;
+  writer["indentation"] = "";
 
   UpstreamResult result;
+  result.json["places"] = Json::Value(Json::arrayValue);
+  std::string pageToken;
+  bool firstPage = true;
   const auto start = std::chrono::steady_clock::now();
+
   try {
     auto client = drogon::HttpClient::newHttpClient(kPlacesHost);
-    auto resp = co_await client->sendRequestCoro(req);
-    result.status = static_cast<int>(resp->getStatusCode());
-    if (auto json = resp->getJsonObject()) result.json = *json;
+    do {
+      // A freshly issued page token can need a moment to become valid. Sleep
+      // without blocking the event loop.
+      if (!firstPage) {
+        co_await drogon::sleepCoro(
+            trantor::EventLoop::getEventLoopOfCurrentThread(),
+            std::chrono::milliseconds(300));
+      }
+      Json::Value body = base;
+      body["pageSize"] = pageSize;
+      if (!pageToken.empty()) body["pageToken"] = pageToken;
+
+      auto req = drogon::HttpRequest::newHttpRequest();
+      req->setMethod(drogon::Post);
+      req->setPath("/v1/places:searchText");
+      req->addHeader("X-Goog-Api-Key", apiKey_);
+      req->addHeader("X-Goog-FieldMask", mask);
+      req->setContentTypeCode(drogon::CT_APPLICATION_JSON);
+      req->setBody(Json::writeString(writer, body));
+
+      try {
+        auto resp = co_await client->sendRequestCoro(req);
+        const int status = static_cast<int>(resp->getStatusCode());
+        if (firstPage) result.status = status;
+        if (status != 200) break;  // keep any pages already collected
+        if (auto json = resp->getJsonObject()) {
+          for (const auto& place : (*json)["places"]) {
+            result.json["places"].append(place);
+          }
+          pageToken = (*json).get("nextPageToken", "").asString();
+        } else {
+          break;
+        }
+      } catch (const std::exception& e) {
+        LOG_ERROR << "searchText page error: " << e.what();
+        if (firstPage) result.status = 0;
+        break;
+      }
+      firstPage = false;
+    } while (!pageToken.empty() &&
+             static_cast<int>(result.json["places"].size()) < p.maxResults);
   } catch (const std::exception& e) {
-    LOG_ERROR << "searchNearby upstream error: " << e.what();
+    LOG_ERROR << "searchText error: " << e.what();
     result.status = 0;
   }
+
   result.upstreamMs = elapsedMs(start);
   co_return result;
 }

--- a/bff/services/GooglePlacesClient.h
+++ b/bff/services/GooglePlacesClient.h
@@ -4,6 +4,7 @@
 #include <json/json.h>
 
 #include <string>
+#include <vector>
 
 /// Result of an upstream JSON call to Google.
 struct UpstreamResult {
@@ -20,20 +21,33 @@ struct PhotoResult {
   long upstreamMs = 0;
 };
 
+/// Inputs for a restaurant Text Search.
+struct SearchParams {
+  std::string query;             // empty → browse all ("restaurant")
+  double lat = 0;
+  double lng = 0;
+  int radius = 5000;
+  int maxResults = 20;           // total wanted; paginated up to ~60
+  bool openNow = false;
+  double minRating = 0;          // <= 0 → no minimum
+  std::vector<int> priceLevels;  // 1..4; empty → any
+  bool includeAtmosphere = false;  // add the pricier atmosphere fields
+};
+
 /// §0 — The ONLY component permitted to make upstream calls to Google Places
-/// (New). All controllers/services go through here, so every outbound call is
-/// auditable in one file. Each method documents the billing SKU tier it
-/// triggers via its field mask.
+/// (New). Every method documents the billing SKU tier it triggers.
 class GooglePlacesClient {
  public:
   explicit GooglePlacesClient(std::string apiKey);
 
-  /// Nearby Search. SKU: ENTERPRISE (mask includes rating/userRatingCount/
-  /// priceLevel). Upstream: POST /v1/places:searchNearby.
-  drogon::Task<UpstreamResult> searchNearby(double lat, double lng, int radius,
-                                            std::string type, int maxResults);
+  /// Text Search with pagination. SKU: ENTERPRISE (+ ATMOSPHERE when
+  /// params.includeAtmosphere). Upstream: POST /v1/places:searchText, paged via
+  /// nextPageToken. Returns a merged {"places":[...]} across pages.
+  drogon::Task<UpstreamResult> searchText(SearchParams params);
 
-  /// Place Details. SKU: ENTERPRISE. Upstream: GET /v1/places/{placeId}.
+  /// Place Details (full). SKU: ENTERPRISE + ATMOSPHERE — includes
+  /// editorialSummary, hours, phone/website, and the atmosphere flags.
+  /// Upstream: GET /v1/places/{placeId}.
   drogon::Task<UpstreamResult> getDetails(std::string placeId);
 
   /// Place Photo. SKU: PHOTO. Upstream: GET /v1/{photoName}/media, then the

--- a/bff/services/PlacesService.cc
+++ b/bff/services/PlacesService.cc
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstdio>
+#include <string>
 
 namespace {
 
@@ -24,6 +25,20 @@ std::string errorBody(const std::string& message) {
   Json::Value e;
   e["error"] = message;
   return serializeCompact(e);
+}
+
+// True only when Google affirmatively reports the flag (null/absent → false),
+// matching the app's strict client-side atmosphere filtering.
+bool flagTrue(const Json::Value& place, const char* field) {
+  return place.isMember(field) && place[field].asBool();
+}
+
+bool hasParking(const Json::Value& place) {
+  if (!place.isMember("parkingOptions")) return false;
+  for (const auto& v : place["parkingOptions"]) {
+    if (v.isBool() && v.asBool()) return true;
+  }
+  return false;
 }
 
 }  // namespace
@@ -64,9 +79,15 @@ Json::Value PlacesService::normalize(const Json::Value& place) {
   if (place.isMember("primaryType")) {
     out["type"] = place["primaryType"].asString();
   }
-  if (place.isMember("currentOpeningHours") &&
-      place["currentOpeningHours"].isMember("openNow")) {
-    out["openNow"] = place["currentOpeningHours"]["openNow"].asBool();
+  if (place.isMember("currentOpeningHours")) {
+    const auto& hours = place["currentOpeningHours"];
+    if (hours.isMember("openNow")) out["openNow"] = hours["openNow"].asBool();
+    if (hours.isMember("weekdayDescriptions")) {
+      out["weekdayHours"] = Json::Value(Json::arrayValue);
+      for (const auto& line : hours["weekdayDescriptions"]) {
+        out["weekdayHours"].append(line.asString());
+      }
+    }
   }
   if (place.isMember("nationalPhoneNumber")) {
     out["phone"] = place["nationalPhoneNumber"].asString();
@@ -74,7 +95,20 @@ Json::Value PlacesService::normalize(const Json::Value& place) {
   if (place.isMember("websiteUri")) {
     out["website"] = place["websiteUri"].asString();
   }
-  // photoRefs is always present (possibly empty) so the client can rely on it.
+  if (place.isMember("editorialSummary")) {
+    out["editorialSummary"] = place["editorialSummary"].get("text", "").asString();
+  }
+  // Atmosphere flags are included only when present (i.e. requested upstream).
+  if (place.isMember("servesBeer")) out["servesBeer"] = place["servesBeer"].asBool();
+  if (place.isMember("servesWine")) out["servesWine"] = place["servesWine"].asBool();
+  if (place.isMember("outdoorSeating")) {
+    out["outdoorSeating"] = place["outdoorSeating"].asBool();
+  }
+  if (place.isMember("goodForGroups")) {
+    out["goodForGroups"] = place["goodForGroups"].asBool();
+  }
+  if (place.isMember("parkingOptions")) out["hasParking"] = hasParking(place);
+  // photoRefs always present (possibly empty) so the client can rely on it.
   out["photoRefs"] = Json::Value(Json::arrayValue);
   if (place.isMember("photos")) {
     for (const auto& photo : place["photos"]) {
@@ -84,23 +118,38 @@ Json::Value PlacesService::normalize(const Json::Value& place) {
   return out;
 }
 
-drogon::Task<ServiceResult> PlacesService::nearby(double lat, double lng,
-                                                  int radius, std::string type,
-                                                  int maxResults) {
-  // Round lat/lng to ~110 m so nearby searches in the same vicinity share a
-  // cache entry.
-  std::array<char, 128> key{};
-  std::snprintf(key.data(), key.size(), "nearby:%.3f:%.3f:%d:%s", lat, lng,
-                radius, type.c_str());
+drogon::Task<ServiceResult> PlacesService::nearby(NearbyQuery q) {
+  const bool usesAtmosphere =
+      q.beer || q.wine || q.patio || q.group || q.parking;
+
+  // Cache key covers every input that changes the result set.
+  std::string priceKey;
+  for (int level : q.priceLevels) priceKey += std::to_string(level);
+  std::array<char, 256> key{};
+  std::snprintf(key.data(), key.size(),
+                "nearby:%.3f:%.3f:%d:%d:%s:o%d:r%.1f:p%s:%d%d%d%d%d", q.lat,
+                q.lng, q.radius, q.maxResults, q.query.c_str(),
+                q.openNow ? 1 : 0, q.minRating, priceKey.c_str(),
+                q.beer ? 1 : 0, q.wine ? 1 : 0, q.patio ? 1 : 0,
+                q.group ? 1 : 0, q.parking ? 1 : 0);
   const std::string cacheKey(key.data());
 
   if (auto cached = cache_->get(cacheKey)) {
     co_return ServiceResult{200, *cached, "HIT", 0, nearbyTtl_};
   }
 
-  const UpstreamResult up =
-      co_await client_->searchNearby(lat, lng, radius, type, maxResults);
+  SearchParams sp;
+  sp.query = q.query;
+  sp.lat = q.lat;
+  sp.lng = q.lng;
+  sp.radius = q.radius;
+  sp.maxResults = q.maxResults;
+  sp.openNow = q.openNow;
+  sp.minRating = q.minRating;
+  sp.priceLevels = q.priceLevels;
+  sp.includeAtmosphere = usesAtmosphere;
 
+  const UpstreamResult up = co_await client_->searchText(sp);
   if (up.status == 0) {
     co_return ServiceResult{502, errorBody("upstream unavailable"), "MISS",
                             up.upstreamMs, 0};
@@ -112,11 +161,16 @@ drogon::Task<ServiceResult> PlacesService::nearby(double lat, double lng,
 
   Json::Value out;
   out["restaurants"] = Json::Value(Json::arrayValue);
-  if (up.json.isMember("places")) {
-    for (const auto& place : up.json["places"]) {
-      out["restaurants"].append(normalize(place));
-    }
+  for (const auto& place : up.json["places"]) {
+    // Client-side atmosphere filtering (Places can't do it server-side).
+    if (q.beer && !flagTrue(place, "servesBeer")) continue;
+    if (q.wine && !flagTrue(place, "servesWine")) continue;
+    if (q.patio && !flagTrue(place, "outdoorSeating")) continue;
+    if (q.group && !flagTrue(place, "goodForGroups")) continue;
+    if (q.parking && !hasParking(place)) continue;
+    out["restaurants"].append(normalize(place));
   }
+
   const std::string body = serialize(out);
   cache_->set(cacheKey, body, nearbyTtl_);
   co_return ServiceResult{200, body, "MISS", up.upstreamMs, nearbyTtl_};
@@ -130,7 +184,6 @@ drogon::Task<ServiceResult> PlacesService::details(std::string placeId) {
   }
 
   const UpstreamResult up = co_await client_->getDetails(placeId);
-
   if (up.status == 0) {
     co_return ServiceResult{502, errorBody("upstream unavailable"), "MISS",
                             up.upstreamMs, 0};

--- a/bff/services/PlacesService.h
+++ b/bff/services/PlacesService.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "GooglePlacesClient.h"
 #include "ICache.h"
@@ -19,6 +20,25 @@ struct ServiceResult {
   int ttlSeconds = 0;          // for the Cache-Control header
 };
 
+/// A normalized nearby query: keyword + location + the full filter set the app
+/// supports (server-side: open/rating/price; atmosphere: beer/wine/patio/group/
+/// parking, applied client-side here since Places can't filter them upstream).
+struct NearbyQuery {
+  std::string query;
+  double lat = 0;
+  double lng = 0;
+  int radius = 5000;
+  int maxResults = 20;
+  bool openNow = false;
+  double minRating = 0;
+  std::vector<int> priceLevels;
+  bool beer = false;
+  bool wine = false;
+  bool patio = false;
+  bool group = false;
+  bool parking = false;
+};
+
 /// Business logic: cache lookup, upstream fetch via GooglePlacesClient, and
 /// normalization to the stable client contract. Never returns raw Google JSON.
 class PlacesService {
@@ -26,12 +46,13 @@ class PlacesService {
   PlacesService(std::shared_ptr<GooglePlacesClient> client,
                 std::shared_ptr<ICache> cache, int nearbyTtl, int detailsTtl);
 
-  drogon::Task<ServiceResult> nearby(double lat, double lng, int radius,
-                                     std::string type, int maxResults);
+  drogon::Task<ServiceResult> nearby(NearbyQuery query);
   drogon::Task<ServiceResult> details(std::string placeId);
 
  private:
-  /// Maps one raw Google place to the normalized restaurant contract.
+  /// Maps one raw Google place to the normalized restaurant contract. Fields
+  /// not present in the upstream payload are simply omitted, so this serves both
+  /// the lean list mask and the full detail mask.
   static Json::Value normalize(const Json::Value& place);
   static std::string serialize(const Json::Value& value);
 


### PR DESCRIPTION
Brings the BFF up to what today's Flutter `PlacesService` does, so the client can later go thin with **no feature regression**.

**/nearby** — now **Text Search + pagination** (nextPageToken, up to ~60, resilient to later-page failure, non-blocking inter-page sleep) instead of capped-20 Nearby Search. Accepts:
- `q` (keyword / cuisine / mood; empty = browse)
- server-side filters: `open`, `min_rating`, `price` (CSV of 1–4)
- atmosphere filters: `beer`/`wine`/`patio`/`group`/`parking` — atmosphere fields are fetched only when used, then filtered server-side (Places can't filter them upstream)

**/details** — full contract: `weekdayHours`, `phone`, `website`, `editorialSummary`, and atmosphere flags. List stays lean/Enterprise; details = Enterprise+Atmosphere.

`normalize()` emits the fuller contract (one function serves both masks). README updated.

Builds clean (cmake + clang, Drogon 1.9.12); structural smoke test passes (routing, all new params parse, metrics labels, upstream attempted → 502 only because the test key is fake). Live end-to-end verification needs a real Places key in `config.json`.