### PR TITLE
feat: show an in-app map when tapping Directions

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,0 +1,58 @@
+name: build-push
+
+# Builds the RandoEats BFF image with Buildah (Podman ecosystem — TekAdept CI
+# standard) and pushes it to GHCR. The shared tekadept-bff host pulls this image
+# on deploy (see ../../tekadept-bff/scripts/deploy-app.sh).
+#
+# The Google Places key is NEVER baked in — config.json is mounted at runtime via
+# the deploy step's --env-file / volume. Build targets amd64 (the Linode is x86;
+# dev Macs are ARM). Uses the prebuilt drogonframework/drogon base, so this build
+# is fast (no framework recompile).
+#
+# NOTE on the registry namespace: images live under ghcr.io/rockncoder while this
+# repo is under Rockncoder. Pushing to the `tekadept` org requires a PAT with
+# `write:packages` on that org, stored as GHCR_PAT (+ GHCR_USER). If absent it
+# falls back to GITHUB_TOKEN (works only if package owner == repo owner).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'bff/**'
+      - '.github/workflows/build-push.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: build-push-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io/rockncoder
+  IMAGE: randoeats-bff
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image (Buildah)
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE }}
+          tags: latest ${{ github.sha }}
+          context: bff
+          containerfiles: bff/Dockerfile
+          archs: amd64
+
+      - name: Push to GHCR
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ env.IMAGE }}
+          tags: latest ${{ github.sha }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCR_USER || github.actor }}
+          password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,91 @@
+name: deploy
+
+# Deploys the RandoEats BFF to the shared tekadept-bff host. Runs after
+# build-push succeeds on main (auto → prod), or manually via dispatch.
+# Independent of the other BFFs — rolls only the randoeats-bff container.
+#
+# RandoEats takes a config FILE (not env vars): its entrypoint is
+# `randoeats_bff /app/config.json`. The config (with the Google Places key) is
+# written from the RANDOEATS_CONFIG_JSON secret and mounted read-only — it is
+# never baked into the image.
+#
+# Required repo secrets:
+#   BFF_HOST / BFF_STAGING_HOST — box IPs
+#   LINODE_SSH_KEY              — tekadept-linode private key
+#   RANDOEATS_CONFIG_JSON       — full config.json contents (Places key, cache, CORS)
+
+on:
+  workflow_run:
+    workflows: ["build-push"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "prod or staging"
+        default: "prod"
+      image_tag:
+        description: "image tag to deploy (default = latest)"
+        default: "latest"
+
+concurrency:
+  group: deploy-randoeats-${{ github.event.inputs.environment || 'prod' }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve params
+        id: p
+        run: |
+          ENVIRONMENT="${{ github.event.inputs.environment || 'prod' }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.image_tag }}"
+          else
+            TAG="${{ github.event.workflow_run.head_sha }}"
+          fi
+          echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if [ "$ENVIRONMENT" = "staging" ]; then
+            echo "host=${{ secrets.BFF_STAGING_HOST }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "host=${{ secrets.BFF_HOST }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: SSH setup
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.LINODE_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "${{ steps.p.outputs.host }}" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Ship Caddy fragment
+        run: |
+          scp -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new \
+            deploy/randoeats.caddy \
+            root@${{ steps.p.outputs.host }}:/etc/caddy/conf.d/randoeats.caddy
+          ssh -i ~/.ssh/id_ed25519 root@${{ steps.p.outputs.host }} \
+            'caddy reload --config /etc/caddy/Caddyfile 2>/dev/null || systemctl reload caddy'
+
+      - name: Write config.json (Places key) + log dir
+        run: |
+          ssh -i ~/.ssh/id_ed25519 root@${{ steps.p.outputs.host }} \
+            "mkdir -p /etc/randoeats /var/log/randoeats && \
+             cat > /etc/randoeats/config-${{ steps.p.outputs.environment }}.json && \
+             chmod 600 /etc/randoeats/config-${{ steps.p.outputs.environment }}.json" <<'CFGEOF'
+          ${{ secrets.RANDOEATS_CONFIG_JSON }}
+          CFGEOF
+
+      - name: Deploy container
+        run: |
+          ssh -i ~/.ssh/id_ed25519 root@${{ steps.p.outputs.host }} \
+            "tekadept-deploy \
+              APP=randoeats-bff-${{ steps.p.outputs.environment }} \
+              IMAGE=ghcr.io/rockncoder/randoeats-bff:${{ steps.p.outputs.tag }} \
+              HOST_PORT=8848 CONTAINER_PORT=8848 \
+              MOUNTS='/etc/randoeats/config-${{ steps.p.outputs.environment }}.json:/app/config.json:ro /var/log/randoeats:/var/log/randoeats' \
+              HEALTH_PATH=/api/v1/health"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,9 @@ jobs:
   deploy:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v4
 
@@ -79,6 +82,11 @@ jobs:
              chmod 600 /etc/randoeats/config-${{ steps.p.outputs.environment }}.json" <<'CFGEOF'
           ${{ secrets.RANDOEATS_CONFIG_JSON }}
           CFGEOF
+
+      - name: Log box into GHCR (ephemeral token; images stay private)
+        run: |
+          ssh -i ~/.ssh/id_ed25519 root@${{ steps.p.outputs.host }} \
+            "echo '${{ secrets.GITHUB_TOKEN }}' | podman login ghcr.io -u ${{ github.repository_owner }} --password-stdin"
 
       - name: Deploy container
         run: |

--- a/bff/services/GooglePlacesClient.cc
+++ b/bff/services/GooglePlacesClient.cc
@@ -96,6 +96,9 @@ drogon::Task<UpstreamResult> GooglePlacesClient::searchText(SearchParams p) {
       auto req = drogon::HttpRequest::newHttpRequest();
       req->setMethod(drogon::Post);
       req->setPath("/v1/places:searchText");
+      // Google's endpoint needs the literal ':' — Drogon would otherwise
+      // percent-encode it to %3A, which the API answers with 404.
+      req->setPathEncode(false);
       req->addHeader("X-Goog-Api-Key", apiKey_);
       req->addHeader("X-Goog-FieldMask", mask);
       req->setContentTypeCode(drogon::CT_APPLICATION_JSON);

--- a/bff/services/GooglePlacesClient.cc
+++ b/bff/services/GooglePlacesClient.cc
@@ -8,10 +8,13 @@ namespace {
 constexpr char kPlacesHost[] = "https://places.googleapis.com";
 
 // SKU: ENTERPRISE — list view. rating/userRatingCount/priceLevel set the tier.
+// weekdayDescriptions rides along inside the already-billed currentOpeningHours
+// field, so the detail view can show hours without a separate details call.
 constexpr char kNearbyMask[] =
     "places.id,places.displayName,places.formattedAddress,places.location,"
     "places.rating,places.userRatingCount,places.priceLevel,"
-    "places.primaryType,places.currentOpeningHours.openNow,places.photos";
+    "places.primaryType,places.currentOpeningHours.openNow,"
+    "places.currentOpeningHours.weekdayDescriptions,places.photos";
 
 // Added to the list mask only when an atmosphere filter is active. SKU bumps to
 // ENTERPRISE + ATMOSPHERE for that request.

--- a/deploy/randoeats.caddy
+++ b/deploy/randoeats.caddy
@@ -1,0 +1,6 @@
+# randoeats — Drogon BFF proxying Google Places (in-memory cache, no DB).
+# Shipped to tekadept-bff at /etc/caddy/conf.d/randoeats.caddy by deploy.yml.
+# The Google Places key lives in the mounted config.json, never in the image.
+api.randoeats.com {
+    reverse_proxy localhost:8848
+}

--- a/lib/models/restaurant.dart
+++ b/lib/models/restaurant.dart
@@ -65,6 +65,47 @@ class Restaurant extends Equatable {
     );
   }
 
+  /// Creates a [Restaurant] from the RandoEats BFF's normalized shape.
+  ///
+  /// The BFF already flattens Google's response (e.g. `location.lat`,
+  /// `ratingCount`, integer `priceLevel`, a single `type`, and `photoRefs`),
+  /// so this factory is a straight field map. Atmosphere flags, phone, hours
+  /// and editorial text are present only when the BFF requested them (nearby vs
+  /// details), and are null otherwise.
+  factory Restaurant.fromBff(Map<String, dynamic> json) {
+    final location = json['location'] as Map<String, dynamic>?;
+    final photoRefs =
+        (json['photoRefs'] as List<dynamic>?)?.whereType<String>().toList() ??
+        const <String>[];
+    final type = json['type'] as String?;
+    final weekday = (json['weekdayHours'] as List<dynamic>?)
+        ?.map((e) => e.toString())
+        .toList();
+
+    return Restaurant(
+      placeId: json['id'] as String? ?? '',
+      name: json['name'] as String? ?? 'Unknown',
+      address: json['address'] as String? ?? '',
+      latitude: (location?['lat'] as num?)?.toDouble() ?? 0,
+      longitude: (location?['lng'] as num?)?.toDouble() ?? 0,
+      rating: (json['rating'] as num?)?.toDouble(),
+      priceLevel: _priceLevelLabel((json['priceLevel'] as num?)?.toInt()),
+      types: type == null ? const [] : [type],
+      photoReference: photoRefs.isEmpty ? null : photoRefs.first,
+      photoReferences: photoRefs,
+      isOpen: json['openNow'] as bool?,
+      totalRatings: (json['ratingCount'] as num?)?.toInt(),
+      servesBeer: json['servesBeer'] as bool?,
+      servesWine: json['servesWine'] as bool?,
+      outdoorSeating: json['outdoorSeating'] as bool?,
+      goodForGroups: json['goodForGroups'] as bool?,
+      hasParking: json['hasParking'] as bool?,
+      phoneNumber: json['phone'] as String?,
+      weekdayHours: (weekday == null || weekday.isEmpty) ? null : weekday,
+      editorialSummary: json['editorialSummary'] as String?,
+    );
+  }
+
   /// Unique identifier from Google Places.
   @HiveField(0)
   final String placeId;
@@ -164,6 +205,17 @@ class Restaurant extends Equatable {
       _ => null,
     };
   }
+
+  /// Maps the BFF's integer price level (0–4) to the same display string used
+  /// by [_parsePriceLevelNew].
+  static String? _priceLevelLabel(int? level) => switch (level) {
+    0 => 'Free',
+    1 => r'$',
+    2 => r'$$',
+    3 => r'$$$',
+    4 => r'$$$$',
+    _ => null,
+  };
 
   /// Pulls the per-day opening-hours strings from a Places opening-hours map.
   static List<String>? _parseWeekdayHours(Map<String, dynamic>? hours) {

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -784,7 +784,7 @@ class _HoursSectionState extends State<_HoursSection> {
 /// (parking/beer/wine), shared + cached by placeId so the chips fetch once.
 // ignore: specify_nonobvious_property_types
 final _atmosphereProvider = FutureProvider.family<PlaceAtmosphere, String>(
-  (ref, placeId) => PlacesService.instance.fetchAtmosphere(placeId),
+  (ref, placeId) => ref.watch(placesServiceProvider).fetchAtmosphere(placeId),
 );
 
 /// An atmosphere indicator chip (parking/beer/wine). Uses the value from the

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:randoeats/blocs/blocs.dart';
 import 'package:randoeats/config/config.dart';
 import 'package:randoeats/models/models.dart';
@@ -578,25 +579,14 @@ class DetailScreen extends ConsumerWidget {
     }
   }
 
-  Future<void> _openMaps(BuildContext context) async {
-    final url = Uri.parse(
-      'https://www.google.com/maps/dir/?api=1'
-      '&destination=${restaurant.latitude},${restaurant.longitude}'
-      '&destination_place_id=${restaurant.placeId}',
+  Future<void> _openMaps(BuildContext context) {
+    // Show the location in an in-app map sheet rather than jumping out to the
+    // external Maps app, which is disorienting to return from.
+    return RestaurantMapSheet.show(
+      context,
+      coordinates: LatLng(restaurant.latitude, restaurant.longitude),
+      name: restaurant.name,
     );
-
-    if (await canLaunchUrl(url)) {
-      await launchUrl(url, mode: LaunchMode.externalApplication);
-    } else {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: const Text('Unable to open maps'),
-            backgroundColor: GoogieColors.coral,
-          ),
-        );
-      }
-    }
   }
 }
 

--- a/lib/services/places_service.dart
+++ b/lib/services/places_service.dart
@@ -1,5 +1,13 @@
 import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:randoeats/models/models.dart';
+
+/// Provides the shared [PlacesService]. Injected (rather than referenced as a
+/// singleton) so widgets/providers can be given a fake in tests and avoid live
+/// network calls.
+final placesServiceProvider = Provider<PlacesService>(
+  (ref) => PlacesService.instance,
+);
 
 /// Atmosphere flags fetched for a single place on its detail view. Each is
 /// true/false when Google reports it, or null when unknown.
@@ -32,7 +40,12 @@ class PlacesError extends PlacesResult {
   final String message;
 }
 
-/// Service for interacting with Google Places API (New).
+/// Client for the RandoEats BFF (`api.randoeats.com`).
+///
+/// The app no longer talks to Google Places directly: the BFF holds the
+/// (IP-restricted) API key, requests the right field masks, normalizes the
+/// response, and caches nearby/details lookups. This class just shapes the
+/// query, calls the BFF, and maps its normalized JSON back into [Restaurant]s.
 class PlacesService {
   /// Creates a [PlacesService] with optional custom Dio client.
   PlacesService({Dio? client}) : _client = client ?? Dio();
@@ -44,48 +57,12 @@ class PlacesService {
 
   final Dio _client;
 
-  /// Google Places API key from dart-define.
-  static const _apiKey = String.fromEnvironment('GOOGLE_PLACES_API_KEY');
-
-  /// Base URL for Places API (New).
-  static const _baseUrl = 'https://places.googleapis.com/v1';
-
-  /// Field mask for restaurant search - Pro tier fields.
-  static const _fieldMask =
-      'places.id,'
-      'places.displayName,'
-      'places.formattedAddress,'
-      'places.location,'
-      'places.rating,'
-      'places.userRatingCount,'
-      'places.priceLevel,'
-      'places.photos,'
-      'places.primaryType,'
-      'places.nationalPhoneNumber,'
-      'places.currentOpeningHours,'
-      'places.editorialSummary';
-
-  /// Extra ("atmosphere") fields, requested only when an atmosphere filter is
-  /// active — these push the request into Google's pricier SKU.
-  static const _atmosphereFields =
-      'places.servesBeer,'
-      'places.servesWine,'
-      'places.outdoorSeating,'
-      'places.goodForGroups,'
-      'places.parkingOptions';
-
-  static String _fieldMaskFor(SpotFilters filters) =>
-      filters.usesAtmosphere ? '$_fieldMask,$_atmosphereFields' : _fieldMask;
-
-  static List<String> _priceLevelEnums(Set<int> levels) {
-    const names = {
-      1: 'PRICE_LEVEL_INEXPENSIVE',
-      2: 'PRICE_LEVEL_MODERATE',
-      3: 'PRICE_LEVEL_EXPENSIVE',
-      4: 'PRICE_LEVEL_VERY_EXPENSIVE',
-    };
-    return levels.map((l) => names[l]).whereType<String>().toList();
-  }
+  /// Base URL for the RandoEats BFF restaurant routes. Overridable at build
+  /// time (e.g. for staging) via `--dart-define=RANDOEATS_API_URL=...`.
+  static const _baseUrl = String.fromEnvironment(
+    'RANDOEATS_API_URL',
+    defaultValue: 'https://api.randoeats.com/api/v1/restaurants',
+  );
 
   /// Fetches nearby restaurants based on location and optional mood.
   ///
@@ -94,6 +71,10 @@ class PlacesService {
   /// [excludePlaceIds] are places to exclude from results.
   /// [radiusMeters] is the search radius in meters (default 5000).
   /// [maxResultCount] is the maximum number of results to return (default 50).
+  ///
+  /// The BFF applies the server-side facets (open now, rating, price) and the
+  /// pricier atmosphere facets (beer/wine/patio/groups/parking); only
+  /// [excludePlaceIds] is applied here, since it's driven by local history.
   Future<PlacesResult> getNearbyRestaurants({
     required double latitude,
     required double longitude,
@@ -103,187 +84,79 @@ class PlacesService {
     int maxResultCount = 50,
     SpotFilters filters = const SpotFilters(),
   }) async {
-    if (_apiKey.isEmpty) {
-      return const PlacesError(
-        'Google Places API key not configured. '
-        'Please set GOOGLE_PLACES_API_KEY.',
-      );
-    }
-
     try {
       // Cuisine chips drive the text query when there's no typed mood.
       final keyword =
           _extractKeyword(mood) ??
           (filters.cuisines.isNotEmpty ? filters.cuisines.join(' ') : null);
-      final fieldMask = _fieldMaskFor(filters);
 
-      // Always use Text Search: it supports pagination (up to ~60 results),
-      // whereas Nearby Search caps at 20 with no page token. An empty keyword
-      // browses all nearby restaurants.
-      final restaurants = await _textSearchRestaurants(
-        latitude: latitude,
-        longitude: longitude,
-        query: keyword ?? '',
-        radiusMeters: radiusMeters,
-        maxResultCount: maxResultCount,
-        fieldMask: fieldMask,
-        filters: filters,
+      final query = <String, dynamic>{
+        'lat': latitude,
+        'lng': longitude,
+        'radius': radiusMeters,
+        'max': maxResultCount,
+        if (keyword != null && keyword.trim().isNotEmpty) 'q': keyword.trim(),
+        if (filters.openNow) 'open': 'true',
+        if (filters.minRating != null) 'min_rating': filters.minRating,
+        if (filters.priceLevels.isNotEmpty)
+          'price': (filters.priceLevels.toList()..sort()).join(','),
+        if (filters.servesBeer) 'beer': 'true',
+        if (filters.servesWine) 'wine': 'true',
+        if (filters.outdoorSeating) 'patio': 'true',
+        if (filters.goodForGroups) 'group': 'true',
+        if (filters.hasParking) 'parking': 'true',
+      };
+
+      final response = await _client.get<Map<String, dynamic>>(
+        '$_baseUrl/nearby',
+        queryParameters: query,
       );
 
-      // Filter out excluded places, then apply the atmosphere facets
-      // client-side — the Places API can't filter these server-side, so we
-      // keep only places it confirms match (a null/unknown value is excluded).
-      var filtered = restaurants.where(
-        (r) => !excludePlaceIds.contains(r.placeId),
-      );
-      if (filters.servesBeer) {
-        filtered = filtered.where((r) => r.servesBeer ?? false);
+      if (response.statusCode != 200) {
+        return PlacesError('HTTP ${response.statusCode}: ${response.data}');
       }
-      if (filters.servesWine) {
-        filtered = filtered.where((r) => r.servesWine ?? false);
+      final data = response.data;
+      if (data == null) {
+        return const PlacesError('Empty response from server.');
       }
-      if (filters.outdoorSeating) {
-        filtered = filtered.where((r) => r.outdoorSeating ?? false);
-      }
-      if (filters.goodForGroups) {
-        filtered = filtered.where((r) => r.goodForGroups ?? false);
-      }
-      if (filters.hasParking) {
-        filtered = filtered.where((r) => r.hasParking ?? false);
+      if (data.containsKey('error')) {
+        return PlacesError('Server error: ${data['error']}');
       }
 
-      return PlacesSuccess(filtered.toList());
+      final restaurants = (data['restaurants'] as List<dynamic>? ?? [])
+          .map((e) => Restaurant.fromBff(e as Map<String, dynamic>))
+          .where((r) => !excludePlaceIds.contains(r.placeId))
+          .toList();
+      return PlacesSuccess(restaurants);
+    } on DioException catch (e) {
+      return PlacesError('Failed to fetch restaurants: ${e.message}');
     } on Exception catch (e) {
       return PlacesError('Failed to fetch restaurants: $e');
     }
   }
 
-  /// Searches for restaurants using text query via Places API (New).
-  Future<List<Restaurant>> _textSearchRestaurants({
-    required double latitude,
-    required double longitude,
-    required String query,
-    required int radiusMeters,
-    required int maxResultCount,
-    required String fieldMask,
-    required SpotFilters filters,
-  }) async {
-    final baseData = <String, dynamic>{
-      'textQuery': query.trim().isEmpty ? 'restaurant' : '$query restaurant',
-      'includedType': 'restaurant',
-      'locationBias': {
-        'circle': {
-          'center': {'latitude': latitude, 'longitude': longitude},
-          'radius': radiusMeters.toDouble(),
-        },
-      },
-    };
-    // Cheap server-side filters supported by Text Search.
-    if (filters.openNow) baseData['openNow'] = true;
-    if (filters.minRating != null) baseData['minRating'] = filters.minRating;
-    if (filters.priceLevels.isNotEmpty) {
-      baseData['priceLevels'] = _priceLevelEnums(filters.priceLevels);
-    }
-
-    // Text Search returns at most 20 results per page. Page through with
-    // nextPageToken until we have enough or Google stops returning a token
-    // (it allows up to ~60 total). pageSize must stay constant across pages
-    // when a pageToken is supplied, so trim any overflow at the end.
-    final pageSize = maxResultCount.clamp(1, 20);
-    final pagedMask = '$fieldMask,nextPageToken';
-    final results = <Restaurant>[];
-    String? pageToken;
-    var firstPage = true;
-    do {
-      // A freshly issued page token can take a moment to become valid.
-      if (!firstPage) {
-        await Future<void>.delayed(const Duration(milliseconds: 300));
-      }
-      final data = <String, dynamic>{
-        ...baseData,
-        'pageSize': pageSize,
-        'pageToken': ?pageToken,
-      };
-      try {
-        final response = await _client.post<Map<String, dynamic>>(
-          '$_baseUrl/places:searchText',
-          options: Options(
-            headers: {
-              'Content-Type': 'application/json',
-              'X-Goog-Api-Key': _apiKey,
-              'X-Goog-FieldMask': pagedMask,
-            },
-          ),
-          data: data,
-        );
-        results.addAll(_parseResponse(response));
-        pageToken = response.data?['nextPageToken'] as String?;
-      } on Exception {
-        // A failed first page is a real error worth surfacing; a failed later
-        // page just ends pagination with whatever we already collected.
-        if (results.isEmpty) rethrow;
-        break;
-      }
-      firstPage = false;
-    } while (pageToken != null && results.length < maxResultCount);
-
-    return results.length > maxResultCount
-        ? results.sublist(0, maxResultCount)
-        : results;
-  }
-
-  /// Fetches atmosphere flags (parking, beer, wine) for a single place via
-  /// Place Details (New).
+  /// Fetches atmosphere flags (parking, beer, wine) for a single place.
   ///
   /// Called from the detail screen so those chips appear even when the search
-  /// didn't request the (pricier) atmosphere fields — one cheap lookup per
-  /// opened place rather than atmosphere fields on every result.
+  /// didn't request the atmosphere fields — one cheap BFF details lookup per
+  /// opened place. The BFF caches details, so repeat opens are free.
   Future<PlaceAtmosphere> fetchAtmosphere(String placeId) async {
     const empty = (hasParking: null, servesBeer: null, servesWine: null);
-    if (placeId.isEmpty || _apiKey.isEmpty) return empty;
+    if (placeId.isEmpty) return empty;
     try {
       final response = await _client.get<Map<String, dynamic>>(
-        '$_baseUrl/places/$placeId',
-        options: Options(
-          headers: {
-            'X-Goog-Api-Key': _apiKey,
-            'X-Goog-FieldMask': 'parkingOptions,servesBeer,servesWine',
-          },
-        ),
+        '$_baseUrl/$placeId',
       );
       final data = response.data;
-      final parking = data?['parkingOptions'] as Map<String, dynamic>?;
+      if (data == null || data.containsKey('error')) return empty;
       return (
-        hasParking: parking?.values.any((v) => v == true),
-        servesBeer: data?['servesBeer'] as bool?,
-        servesWine: data?['servesWine'] as bool?,
+        hasParking: data['hasParking'] as bool?,
+        servesBeer: data['servesBeer'] as bool?,
+        servesWine: data['servesWine'] as bool?,
       );
     } on DioException {
       return empty;
     }
-  }
-
-  /// Parses the API response and returns a list of restaurants.
-  List<Restaurant> _parseResponse(Response<Map<String, dynamic>> response) {
-    if (response.statusCode != 200) {
-      throw Exception(
-        'HTTP ${response.statusCode}: ${response.data}',
-      );
-    }
-
-    final data = response.data!;
-
-    // Check for API errors
-    if (data.containsKey('error')) {
-      final error = data['error'] as Map<String, dynamic>;
-      throw Exception('Places API error: ${error['message']}');
-    }
-
-    final places = data['places'] as List<dynamic>? ?? [];
-
-    return places
-        .map((p) => Restaurant.fromPlacesApiNew(p as Map<String, dynamic>))
-        .toList();
   }
 
   /// Extracts a search keyword from mood input.
@@ -323,18 +196,31 @@ class PlacesService {
     return null;
   }
 
-  /// Builds a photo URL for a given photo name (new API format).
+  /// Builds a BFF photo URL for a given photo name.
   ///
-  /// [photoName] is the full resource name from the API response,
-  /// e.g., "places/ChIJ.../photos/AWU5..."
+  /// [photoName] is the full Places resource name from a [Restaurant], e.g.
+  /// "places/ChIJ.../photos/AWU5...". The BFF proxies the image bytes (and
+  /// holds the API key), so this URL can be loaded directly by the UI.
   ///
-  /// Returns null if no API key or photo name.
+  /// Returns null when there's no photo name.
   String? getPhotoUrl(String? photoName, {int maxWidth = 400}) {
-    if (_apiKey.isEmpty || photoName == null) return null;
+    if (photoName == null || photoName.isEmpty) return null;
 
-    return '$_baseUrl/$photoName/media'
-        '?maxWidthPx=$maxWidth'
-        '&key=$_apiKey';
+    // photoName is "places/{placeId}/photos/{ref}"; the BFF photo route lives
+    // under the place and takes the full name as the photo_ref query param.
+    final segments = photoName.split('/');
+    final placeId = segments.length > 1 && segments.first == 'places'
+        ? segments[1]
+        : 'x';
+
+    return Uri.parse('$_baseUrl/$placeId/photo')
+        .replace(
+          queryParameters: {
+            'photo_ref': photoName,
+            'max_width': '$maxWidth',
+          },
+        )
+        .toString();
   }
 
   /// Disposes the Dio client.

--- a/lib/widgets/restaurant_map_sheet.dart
+++ b/lib/widgets/restaurant_map_sheet.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:randoeats/config/config.dart';
+
+/// A modal bottom sheet that shows a single restaurant on a Google map.
+///
+/// Present it with [RestaurantMapSheet.show]. The sheet covers ~60% of the
+/// screen, has drag-to-dismiss disabled so pan/zoom gestures belong to the map,
+/// and drops one marker on [coordinates] with [name] shown as the title. A ✕ in
+/// the top-right corner dismisses it.
+class RestaurantMapSheet extends StatelessWidget {
+  /// Creates a [RestaurantMapSheet] for [name] at [coordinates].
+  const RestaurantMapSheet({
+    required this.coordinates,
+    required this.name,
+    super.key,
+  });
+
+  /// The restaurant's location; the map centers here and drops its marker.
+  final LatLng coordinates;
+
+  /// The restaurant's name, shown as the title above the map.
+  final String name;
+
+  /// Presents the sheet as a modal bottom sheet over [context].
+  ///
+  /// Returns a future that completes when the sheet is dismissed.
+  static Future<void> show(
+    BuildContext context, {
+    required LatLng coordinates,
+    required String name,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      // Off so the map keeps pan/zoom gestures instead of dismissing the sheet.
+      enableDrag: false,
+      // Allow the sheet to grow past the default (~half-screen) cap so the
+      // fixed 60% height below isn't clipped.
+      isScrollControlled: true,
+      backgroundColor: GoogieColors.cream,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+      ),
+      builder: (_) => RestaurantMapSheet(coordinates: coordinates, name: name),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return SizedBox(
+      height: 0.6 * MediaQuery.of(context).size.height,
+      child: Column(
+        children: [
+          // Title on the left, close (✕) on the right.
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 12, 8, 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    name,
+                    style: theme.textTheme.titleLarge,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                IconButton(
+                  key: const ValueKey('restaurant_map_close'),
+                  icon: const Icon(Icons.close),
+                  tooltip: 'Close',
+                  onPressed: () => Navigator.pop(context),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ClipRRect(
+              borderRadius: const BorderRadius.vertical(
+                bottom: Radius.circular(28),
+              ),
+              child: GoogleMap(
+                initialCameraPosition: CameraPosition(
+                  target: coordinates,
+                  zoom: 15,
+                ),
+                markers: {
+                  Marker(
+                    markerId: const MarkerId('restaurant'),
+                    position: coordinates,
+                    infoWindow: InfoWindow(title: name),
+                  ),
+                },
+                myLocationButtonEnabled: false,
+                zoomControlsEnabled: false,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -10,6 +10,7 @@ export 'rando_eats_button.dart';
 export 'reel_layout.dart';
 export 'region_chip_bar.dart';
 export 'restaurant_card.dart';
+export 'restaurant_map_sheet.dart';
 export 'skeleton_loader.dart';
 export 'slot_machine_list.dart';
 export 'wavy_line.dart';

--- a/test/screens/detail_screen_render_test.dart
+++ b/test/screens/detail_screen_render_test.dart
@@ -11,6 +11,15 @@ import 'package:randoeats/services/services.dart';
 /// constructs it) to catch layout/semantics regressions — e.g. the
 /// "BoxConstraints forces an infinite width" + parentDataDirty flood seen on
 /// the iPad simulator under marionette.
+
+/// Stands in for [PlacesService] so rendering the screen doesn't make a live
+/// atmosphere lookup (which would leave a pending timer in the test).
+class _NoNetworkPlacesService extends PlacesService {
+  @override
+  Future<PlaceAtmosphere> fetchAtmosphere(String placeId) async =>
+      (hasParking: null, servesBeer: null, servesWine: null);
+}
+
 void main() {
   late Directory tempDir;
 
@@ -43,8 +52,11 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
     await tester.pumpWidget(
-      const ProviderScope(
-        child: MaterialApp(home: DetailScreen(restaurant: restaurant)),
+      ProviderScope(
+        overrides: [
+          placesServiceProvider.overrideWithValue(_NoNetworkPlacesService()),
+        ],
+        child: const MaterialApp(home: DetailScreen(restaurant: restaurant)),
       ),
     );
     await tester.pump();
@@ -91,8 +103,11 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
     await tester.pumpWidget(
-      const ProviderScope(
-        child: MaterialApp(home: DetailScreen(restaurant: withPhone)),
+      ProviderScope(
+        overrides: [
+          placesServiceProvider.overrideWithValue(_NoNetworkPlacesService()),
+        ],
+        child: const MaterialApp(home: DetailScreen(restaurant: withPhone)),
       ),
     );
     await tester.pump();

--- a/test/services/places_service_test.dart
+++ b/test/services/places_service_test.dart
@@ -5,6 +5,12 @@ import 'package:randoeats/services/services.dart';
 
 class MockDio extends Mock implements Dio {}
 
+Response<Map<String, dynamic>> _ok(Map<String, dynamic> data) => Response(
+  requestOptions: RequestOptions(path: '/nearby'),
+  statusCode: 200,
+  data: data,
+);
+
 void main() {
   group('PlacesService', () {
     late MockDio mockClient;
@@ -21,31 +27,116 @@ void main() {
     });
 
     group('getNearbyRestaurants', () {
-      test('returns PlacesError when API key is empty', () async {
-        // API key is empty by default in tests (no --dart-define)
+      test('parses restaurants from the BFF response', () async {
+        when(
+          () => mockClient.get<Map<String, dynamic>>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          ),
+        ).thenAnswer(
+          (_) async => _ok({
+            'restaurants': [
+              {
+                'id': 'abc',
+                'name': 'Test Diner',
+                'address': '1 Main St',
+                'location': {'lat': 34.0, 'lng': -118.0},
+                'rating': 4.5,
+                'ratingCount': 12,
+                'priceLevel': 2,
+                'type': 'restaurant',
+                'openNow': true,
+                'photoRefs': ['places/abc/photos/xyz'],
+              },
+            ],
+          }),
+        );
+
+        final result = await service.getNearbyRestaurants(
+          latitude: 34,
+          longitude: -118,
+        );
+
+        expect(result, isA<PlacesSuccess>());
+        final restaurants = (result as PlacesSuccess).restaurants;
+        expect(restaurants, hasLength(1));
+        expect(restaurants.first.placeId, 'abc');
+        expect(restaurants.first.name, 'Test Diner');
+        expect(restaurants.first.priceLevel, r'$$');
+        expect(restaurants.first.photoReference, 'places/abc/photos/xyz');
+      });
+
+      test('drops places in excludePlaceIds', () async {
+        when(
+          () => mockClient.get<Map<String, dynamic>>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          ),
+        ).thenAnswer(
+          (_) async => _ok({
+            'restaurants': [
+              {
+                'id': 'keep',
+                'name': 'Keep',
+                'address': '',
+                'location': {'lat': 0, 'lng': 0},
+                'photoRefs': <String>[],
+              },
+              {
+                'id': 'drop',
+                'name': 'Drop',
+                'address': '',
+                'location': {'lat': 0, 'lng': 0},
+                'photoRefs': <String>[],
+              },
+            ],
+          }),
+        );
+
+        final result = await service.getNearbyRestaurants(
+          latitude: 34,
+          longitude: -118,
+          excludePlaceIds: {'drop'},
+        );
+
+        expect(result, isA<PlacesSuccess>());
+        final restaurants = (result as PlacesSuccess).restaurants;
+        expect(restaurants, hasLength(1));
+        expect(restaurants.first.placeId, 'keep');
+      });
+
+      test('returns PlacesError when the request throws', () async {
+        when(
+          () => mockClient.get<Map<String, dynamic>>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          ),
+        ).thenThrow(
+          DioException(requestOptions: RequestOptions(path: '/nearby')),
+        );
+
         final result = await service.getNearbyRestaurants(
           latitude: 34,
           longitude: -118,
         );
 
         expect(result, isA<PlacesError>());
-        expect(
-          (result as PlacesError).message,
-          contains('API key not configured'),
-        );
       });
     });
 
     group('getPhotoUrl', () {
       test('returns null when photoName is null', () {
-        final url = service.getPhotoUrl(null);
-        expect(url, isNull);
+        expect(service.getPhotoUrl(null), isNull);
       });
 
-      test('returns null when API key is empty', () {
-        // API key is empty in test environment
-        final url = service.getPhotoUrl('places/abc/photos/xyz');
-        expect(url, isNull);
+      test('builds a BFF photo URL from the photo name', () {
+        final url = service.getPhotoUrl('places/abc/photos/xyz', maxWidth: 200);
+
+        expect(url, isNotNull);
+        expect(url, contains('/restaurants/abc/photo'));
+        final parsed = Uri.parse(url!);
+        expect(parsed.queryParameters['photo_ref'], 'places/abc/photos/xyz');
+        expect(parsed.queryParameters['max_width'], '200');
       });
     });
 

--- a/test/widgets/restaurant_map_sheet_test.dart
+++ b/test/widgets/restaurant_map_sheet_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:randoeats/widgets/restaurant_map_sheet.dart';
+
+void main() {
+  group('RestaurantMapSheet', () {
+    const coordinates = LatLng(37.7749, -122.4194);
+    const name = 'Zuni Café';
+
+    Widget host() => MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () => RestaurantMapSheet.show(
+              context,
+              coordinates: coordinates,
+              name: name,
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+
+    testWidgets('shows the restaurant name as the title and a close button', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host());
+      await tester.tap(find.text('open'));
+      await tester.pump(); // start the sheet route
+      await tester.pump(const Duration(milliseconds: 350)); // finish animation
+
+      expect(find.text(name), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('restaurant_map_close')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('the close button dismisses the sheet', (tester) async {
+      await tester.pumpWidget(host());
+      await tester.tap(find.text('open'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+      expect(find.text(name), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('restaurant_map_close')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.text(name), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Tapping **Directions** launched the external Maps app, which is disorienting to get back from. It now opens the location in an in-app modal (`RestaurantMapSheet`): a ~60%-height Google map with a single marker, the restaurant name as the title, and a ✕ close button. Drag-to-dismiss is disabled so map pan/zoom gestures aren't hijacked.

- New reusable `RestaurantMapSheet` widget (uses `google_maps_flutter`, already a dependency; exported from the widgets barrel).
- Detail screen's Directions action calls `RestaurantMapSheet.show(...)` instead of `launchUrl(externalApplication)`.
- Works on mobile (native maps key) and web (WEB_API_KEY injected into index.html at build).

`dart format` clean · `flutter analyze` no issues · `flutter test` 337 passing (adds `restaurant_map_sheet_test.dart`).