### PR TITLE
refactor: adopt <screen><type><n> widget key convention

### DIFF
--- a/docs/WIDGET_KEYS.md
+++ b/docs/WIDGET_KEYS.md
@@ -1,0 +1,176 @@
+# Widget Key Convention & Map
+
+Reference for every keyed widget in the app and the naming convention they follow.
+Keys drive widget tests (`find.byKey`) and marionette automation, so keep them
+stable and consistent.
+
+## Convention
+
+```
+ValueKey<String>('<screenPrefix><SemanticName><TypeSuffix><N>')   // camelCase
+```
+
+- **screenPrefix** — from the screen widget class name, drop the `Screen`/`Page`
+  suffix, camelCase. Exception: the detail screen uses `restaurantDetail`
+  (class is `DetailScreen`).
+- **SemanticName** — the widget's purpose (e.g. `Navigate`, `Hours`, `SaveSpot`).
+- **TypeSuffix** — by widget type:
+
+  | Widget type | Suffix |
+  |---|---|
+  | Button / IconButton / FloatingActionButton | `Btn` |
+  | GestureDetector / InkWell (incl. tappable chips) | `Tap` |
+  | TextField / TextFormField | `Input` |
+  | DropdownButton / PopupMenuButton | `Menu` |
+  | Switch / Checkbox / Radio | `Toggle` |
+  | PageView / Swiper | `Carousel` |
+  | RefreshIndicator | `Refresh` |
+  | Text showing data (name, hours, distance, cuisine) | `Text` |
+  | Image / CachedNetworkImage | `Img` |
+  | ListView / GridView | `List` |
+  | Card | `Card` |
+  | GoogleMap | `Map` |
+  | BottomSheet | `Sheet` |
+
+- **N** — starts at 1; increments only for repeats of the same
+  screen + SemanticName + TypeSuffix (e.g. two photos → `Photo1`, `Photo2`).
+
+**Loop items:** when list items are a named widget class (`_FacetChip`,
+`RestaurantCard`, `_ScopeChip`, …) the key keeps the item's dynamic identity as
+an interpolated suffix (e.g. `resultsReelCell_${placeId}_$index`) so specific
+items stay targetable. Otherwise the `ListView`/`GridView` itself is keyed
+(`...List1`) and individual items are not.
+
+**Do NOT key:** layout widgets (Column, Row, Stack, Padding, SizedBox,
+Container), decorative widgets, or children already inside a keyed parent
+list/carousel.
+
+## Key map
+
+### splash (`SplashScreen`)
+
+| Widget | Old key | New key |
+|---|---|---|
+| Image (animated logo) | — | `splashLogoImg1` |
+
+### home (`HomeScreen`)
+
+| Widget | Old key | New key |
+|---|---|---|
+| TextField (mood) | — | `homeMoodInput1` |
+| ElevatedButton (engage) | — | `homeEngageBtn1` |
+| IconButton (clear input) | — | `homeClearBtn1` |
+| IconButton (settings) | — | `homeSettingsBtn1` |
+| TextButton (retry) | — | `homeRetryBtn1` |
+| Text (wordmark) | — | `homeWordmarkText1` |
+
+### about (`AboutScreen`)
+
+| Widget | Old key | New key |
+|---|---|---|
+| IconButton (back) | `about_back` | `aboutBackBtn1` |
+| Text (version) | `about_version` | `aboutVersionText1` |
+
+### settings (`SettingsScreen`)
+
+| Widget | Old key | New key |
+|---|---|---|
+| Switch (calm mode) | `setting_calm_mode` | `settingsCalmModeToggle1` |
+| GestureDetector (theme swatch, loop) | `theme_swatch_${appTheme.id}` | `settingsThemeSwatch_${appTheme.id}` |
+
+### regionDraw (`RegionDrawScreen`)
+
+| Widget | Old key | New key |
+|---|---|---|
+| TextField (name) | `region_name_field` | `regionDrawNameInput1` |
+| FilledButton (dialog save confirm) | `region_save_confirm` | `regionDrawSaveConfirmBtn1` |
+| TextButton (appBar save) | `region_save_button` | `regionDrawSaveBtn1` |
+| FloatingActionButton (draw) | `region_draw_fab` | `regionDrawDrawBtn1` |
+
+### results (`ResultsScreen` + FilterChipBar, RegionChipBar, MultiReelSlotMachine)
+
+| Widget | Old key | New key |
+|---|---|---|
+| RandoEatsButton (spin) | `spin_button` | `resultsSpinBtn1` |
+| Container (count readout) | `result_count` | `resultsResultCountText1` |
+| IconButton (quick tune) | `quick_tune_button` | `resultsQuickTuneBtn1` |
+| IconButton (about) | `about_button` | `resultsAboutBtn1` |
+| IconButton (refresh) | — | `resultsRefreshBtn1` |
+| IconButton (settings) | — | `resultsSettingsBtn1` |
+| TextButton (notice show-all) | `notice_show_all` | `resultsNoticeShowAllBtn1` |
+| IconButton (notice dismiss) | `notice_dismiss` | `resultsNoticeDismissBtn1` |
+| ElevatedButton (try again) | — | `resultsTryAgainBtn1` |
+| Text (error message) | — | `resultsErrorText1` |
+| TextField (save-spot name) | `spot_name_field` | `resultsSpotNameInput1` |
+| FilledButton (save-spot confirm) | `spot_save_confirm` | `resultsSpotSaveConfirmBtn1` |
+| TextButton (save-spot cancel) | — | `resultsSpotSaveCancelBtn1` |
+| TextField (rename-area) | — | `resultsRenameAreaInput1` |
+| FilledButton (rename-area save) | — | `resultsRenameAreaSaveBtn1` |
+| TextButton (rename-area cancel) | — | `resultsRenameAreaCancelBtn1` |
+| ChoiceChip (quick-tune price, loop) | `tune_price_$level` | `resultsTunePriceChip_$level` |
+| _FacetChip (cuisine, loop) | `filter_cuisine_${c.code}` | `resultsCuisineChip_${c.code}` |
+| _FacetChip (price, loop) | `filter_price_$level` | `resultsPriceChip_$level` |
+| _FacetChip (beer) | `filter_beer` | `resultsFilterBeerTap1` |
+| _FacetChip (wine) | `filter_wine` | `resultsFilterWineTap1` |
+| _FacetChip (patio) | `filter_patio` | `resultsFilterPatioTap1` |
+| _FacetChip (parking) | `filter_parking` | `resultsFilterParkingTap1` |
+| _FacetChip (group) | `filter_group` | `resultsFilterGroupTap1` |
+| _FacetChip (open) | `filter_open` | `resultsFilterOpenTap1` |
+| _FacetChip (rating) | `filter_rating` | `resultsFilterRatingTap1` |
+| ActionChip (clear all) | `filter_clear_all` | `resultsClearAllTap1` |
+| ActionChip (save spot) | `filter_save_spot` | `resultsSaveSpotTap1` |
+| ListView (reel) | `reel_list` | `resultsReelList1` |
+| RestaurantCard (reel cell, loop) | `reel_cell_${placeId}_$index` | `resultsReelCell_${placeId}_$index` |
+| _ScopeChip (near me) | `region_chip_near_me` | `resultsRegionNearMeTap1` |
+| _ScopeChip (region, loop) | `region_chip_${region.id}` | `resultsRegionChip_${region.id}` |
+| _ScopeChip (add area) | `region_chip_add` | `resultsRegionAddTap1` |
+| ListTile (menu rename) | `region_menu_rename` | `resultsRegionMenuRenameTap1` |
+| ListTile (menu delete) | `region_menu_delete` | `resultsRegionMenuDeleteTap1` |
+
+### restaurantDetail (`DetailScreen` + RestaurantDirectionsSheet)
+
+| Widget | Old key | New key |
+|---|---|---|
+| IconButton (back) | `detail_back` | `restaurantDetailBackBtn1` |
+| Text (name) | — | `restaurantDetailNameText1` |
+| Text (address) | — | `restaurantDetailAddressText1` |
+| Text (description) | `detail_description` | `restaurantDetailDescriptionText1` |
+| Container (rating chip) | — | `restaurantDetailRatingText1` |
+| Container (price chip) | — | `restaurantDetailPriceText1` |
+| Container (open-status chip) | — | `restaurantDetailOpenStatusText1` |
+| _AtmosphereChip (parking) | — | `restaurantDetailParkingText1` |
+| _AtmosphereChip (beer) | — | `restaurantDetailBeerText1` |
+| _AtmosphereChip (wine) | — | `restaurantDetailWineText1` |
+| Container (category chip, loop) | — | `restaurantDetailCategoryText${index+1}` |
+| InkWell (phone/call) | `detail_call` | `restaurantDetailCallTap1` |
+| InkWell (hours) | `detail_hours` | `restaurantDetailHoursText1` |
+| FilledButton (navigate) | `detail_navigate` | `restaurantDetailNavigateBtn1` |
+| FilledButton (rate, loop) | `detail_rate_${ratingType.name}` | `restaurantDetailRate${ratingType.name}Btn1` |
+| PageView (photo carousel) | `detail_photo_carousel` | `restaurantDetailPhotoCarousel1` |
+| Image (photo, loop) | — | `restaurantDetailPhoto${i+1}` |
+| SizedBox (directions sheet root) | — | `restaurantDetailDirectionsSheet1` |
+| IconButton (directions close) | `directions_close` | `restaurantDetailCloseBtn1` |
+| WebViewWidget (directions map) | — | `restaurantDetailDirectionsMap1` |
+| TextButton (open external) | `directions_open_external` | `restaurantDetailOpenExternalBtn1` |
+
+## Decisions & deviations
+
+1. **`restaurantDetail` prefix** — the class is `DetailScreen` (mechanical rule
+   would give `detail`), but the agreed examples use `restaurantDetail`.
+2. **`restaurantDetailHoursText1`** sits on an `InkWell` (type table → `Tap`),
+   kept as `Text` to match the given example.
+3. **Rating buttons** resolve to `restaurantDetailRatethumbsUpBtn1` /
+   `restaurantDetailRatethumbsDownBtn1` (lowercase `thumbs` from the interpolated
+   `ratingType.name`); dynamic identity kept so each stays targetable.
+4. **`detail_abort`** — no such widget (the back arrow replaced the abort
+   button); the corresponding test is a `findsNothing` assertion.
+
+## Known gaps (follow-up)
+
+- **Settings** sliders, action buttons, unit toggles, and category chips are
+  built by shared helper methods called multiple times; keying inside would
+  create duplicate keys. Full coverage needs the helpers parameterized with a
+  per-call key.
+- **Quick-tune `Slider`** — no `Slider` suffix defined in the convention.
+- **`restaurant_map_sheet.dart`** (`restaurant_map_close`) — orphaned (the
+  directions sheet replaced it), left on its old key; out of screen scope.

--- a/lib/screens/about/about_screen.dart
+++ b/lib/screens/about/about_screen.dart
@@ -51,7 +51,7 @@ class _AboutScreenState extends State<AboutScreen> {
       appBar: AppBar(
         title: const Text('About'),
         leading: IconButton(
-          key: const ValueKey('about_back'),
+          key: const ValueKey<String>('aboutBackBtn1'),
           icon: const Icon(Icons.arrow_back),
           onPressed: () => Navigator.of(context).maybePop(),
         ),
@@ -87,7 +87,7 @@ class _AboutScreenState extends State<AboutScreen> {
               const SizedBox(height: 16),
               Text(
                 _version == null ? 'Version …' : 'Version $_version',
-                key: const ValueKey('about_version'),
+                key: const ValueKey<String>('aboutVersionText1'),
                 style: theme.textTheme.bodyLarge?.copyWith(
                   color: GoogieColors.deepTeal,
                   fontWeight: FontWeight.bold,

--- a/lib/screens/detail/detail_screen.dart
+++ b/lib/screens/detail/detail_screen.dart
@@ -83,7 +83,7 @@ class DetailScreen extends ConsumerWidget {
       shape: const CircleBorder(),
       clipBehavior: Clip.antiAlias,
       child: IconButton(
-        key: const ValueKey('detail_back'),
+        key: const ValueKey('restaurantDetailBackBtn1'),
         icon: const Icon(Icons.arrow_back),
         color: GoogieColors.white,
         onPressed: () => context.pop(),
@@ -146,7 +146,7 @@ class DetailScreen extends ConsumerWidget {
     final summary = restaurant.editorialSummary;
     if (summary == null || summary.isEmpty) return const SizedBox.shrink();
     return Padding(
-      key: const ValueKey('detail_description'),
+      key: const ValueKey('restaurantDetailDescriptionText1'),
       padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
       child: Text(
         summary,
@@ -167,6 +167,7 @@ class DetailScreen extends ConsumerWidget {
         children: [
           // Name
           Text(
+            key: const ValueKey('restaurantDetailNameText1'),
             restaurant.name,
             style: theme.textTheme.headlineSmall?.copyWith(
               fontWeight: FontWeight.bold,
@@ -185,6 +186,7 @@ class DetailScreen extends ConsumerWidget {
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
+                  key: const ValueKey('restaurantDetailAddressText1'),
                   restaurant.address,
                   style: theme.textTheme.bodyMedium?.copyWith(
                     color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
@@ -207,6 +209,7 @@ class DetailScreen extends ConsumerWidget {
               // Rating
               if (restaurant.rating != null)
                 _buildChip(
+                  key: const ValueKey('restaurantDetailRatingText1'),
                   icon: Icons.star,
                   iconColor: GoogieColors.onMustardContainer,
                   label: _formatRating(),
@@ -218,6 +221,7 @@ class DetailScreen extends ConsumerWidget {
               // leading dollar-sign icon (it would render as "$ $$").
               if (restaurant.priceLevel != null)
                 _buildChip(
+                  key: const ValueKey('restaurantDetailPriceText1'),
                   label: restaurant.priceLevel!,
                   fill: GoogieColors.turquoiseContainer,
                   textColor: GoogieColors.onTurquoiseContainer,
@@ -226,6 +230,7 @@ class DetailScreen extends ConsumerWidget {
               // Open status
               if (restaurant.isOpen != null)
                 _buildChip(
+                  key: const ValueKey('restaurantDetailOpenStatusText1'),
                   icon: restaurant.isOpen! ? Icons.check_circle : Icons.cancel,
                   iconColor: restaurant.isOpen!
                       ? GoogieColors.statusOpen
@@ -243,6 +248,7 @@ class DetailScreen extends ConsumerWidget {
               // (one Place Details call, shared) so they show even when the
               // search didn't request the atmosphere fields.
               _AtmosphereChip(
+                key: const ValueKey('restaurantDetailParkingText1'),
                 placeId: restaurant.placeId,
                 known: restaurant.hasParking,
                 select: (a) => a.hasParking,
@@ -251,6 +257,7 @@ class DetailScreen extends ConsumerWidget {
                 theme: theme,
               ),
               _AtmosphereChip(
+                key: const ValueKey('restaurantDetailBeerText1'),
                 placeId: restaurant.placeId,
                 known: restaurant.servesBeer,
                 select: (a) => a.servesBeer,
@@ -259,6 +266,7 @@ class DetailScreen extends ConsumerWidget {
                 theme: theme,
               ),
               _AtmosphereChip(
+                key: const ValueKey('restaurantDetailWineText1'),
                 placeId: restaurant.placeId,
                 known: restaurant.servesWine,
                 select: (a) => a.servesWine,
@@ -280,10 +288,10 @@ class DetailScreen extends ConsumerWidget {
             Wrap(
               spacing: 8,
               runSpacing: 8,
-              children: restaurant.types
-                  .take(5)
-                  .map((type) => _buildCategoryChip(type, theme))
-                  .toList(),
+              children: [
+                for (final (i, type) in restaurant.types.take(5).indexed)
+                  _buildCategoryChip(type, theme, i),
+              ],
             ),
           ],
         ],
@@ -297,7 +305,7 @@ class DetailScreen extends ConsumerWidget {
     String phoneNumber,
   ) {
     return InkWell(
-      key: const ValueKey('detail_call'),
+      key: const ValueKey('restaurantDetailCallTap1'),
       onTap: () => _callPhone(context, phoneNumber),
       borderRadius: BorderRadius.circular(8),
       child: Padding(
@@ -328,12 +336,14 @@ class DetailScreen extends ConsumerWidget {
   Widget _buildChip({
     required String label,
     required ThemeData theme,
+    Key? key,
     IconData? icon,
     Color? iconColor,
     Color? fill,
     Color? textColor,
   }) {
     return Container(
+      key: key,
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
       decoration: BoxDecoration(
         color: fill ?? GoogieColors.white,
@@ -366,8 +376,9 @@ class DetailScreen extends ConsumerWidget {
     return rating;
   }
 
-  Widget _buildCategoryChip(String type, ThemeData theme) {
+  Widget _buildCategoryChip(String type, ThemeData theme, int index) {
     return Container(
+      key: ValueKey('restaurantDetailCategoryText${index + 1}'),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: BoxDecoration(
         color: GoogieColors.turquoiseContainer,
@@ -405,7 +416,7 @@ class DetailScreen extends ConsumerWidget {
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Pulse(
         child: FilledButton.icon(
-          key: const ValueKey('detail_navigate'),
+          key: const ValueKey('restaurantDetailNavigateBtn1'),
           onPressed: () => _openMaps(context),
           icon: const Icon(Icons.navigation),
           label: const Text('Directions'),
@@ -506,7 +517,7 @@ class DetailScreen extends ConsumerWidget {
       label: label,
       button: true,
       child: FilledButton.tonal(
-        key: ValueKey('detail_rate_${ratingType.name}'),
+        key: ValueKey('restaurantDetailRate${ratingType.name}Btn1'),
         onPressed: () async {
           final rating = UserRating(
             placeId: restaurant.placeId,
@@ -670,7 +681,7 @@ class _HoursSectionState extends State<_HoursSection> {
       button: true,
       label: 'Opening hours',
       child: InkWell(
-        key: const ValueKey('detail_hours'),
+        key: const ValueKey('restaurantDetailHoursText1'),
         onTap: () => setState(() => _expanded = !_expanded),
         borderRadius: BorderRadius.circular(12),
         child: Padding(
@@ -814,6 +825,7 @@ class _AtmosphereChip extends ConsumerWidget {
     required this.icon,
     required this.label,
     required this.theme,
+    super.key,
   });
 
   final String placeId;
@@ -890,11 +902,12 @@ class _PhotoCarouselState extends State<_PhotoCarousel> {
       fit: StackFit.expand,
       children: [
         PageView.builder(
-          key: const ValueKey('detail_photo_carousel'),
+          key: const ValueKey('restaurantDetailPhotoCarousel1'),
           controller: _controller,
           itemCount: urls.length,
           onPageChanged: (i) => setState(() => _index = i),
           itemBuilder: (context, i) => Image.network(
+            key: ValueKey('restaurantDetailPhoto${i + 1}'),
             urls[i],
             fit: BoxFit.cover,
             width: double.infinity,

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -84,6 +84,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         elevation: 0,
         actions: [
           IconButton(
+            key: const ValueKey<String>('homeSettingsBtn1'),
             icon: Icon(Icons.settings, color: GoogieColors.turquoise),
             onPressed: () => unawaited(context.push<void>(AppRoutes.settings)),
           ),
@@ -152,6 +153,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         const SizedBox(height: 16),
         Text(
           'rand-o-eats',
+          key: const ValueKey<String>('homeWordmarkText1'),
           style: theme.textTheme.displaySmall?.copyWith(
             color: GoogieColors.coral,
             fontWeight: FontWeight.bold,
@@ -191,6 +193,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   Widget _buildMoodInput(ThemeData theme) {
     return TextField(
+      key: const ValueKey<String>('homeMoodInput1'),
       controller: _moodController,
       decoration: InputDecoration(
         hintText: 'e.g., "I want tacos" or "No fast food"',
@@ -203,6 +206,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         ),
         suffixIcon: _moodController.text.isNotEmpty
             ? IconButton(
+                key: const ValueKey<String>('homeClearBtn1'),
                 icon: const Icon(Icons.clear),
                 onPressed: () {
                   _moodController.clear();
@@ -221,6 +225,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final hasLocation = _locationError == null && !_isLoading;
 
     return ElevatedButton(
+      key: const ValueKey<String>('homeEngageBtn1'),
       onPressed: hasLocation ? _onEngagePressed : null,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -291,6 +296,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             ),
           ),
           TextButton(
+            key: const ValueKey<String>('homeRetryBtn1'),
             onPressed: _checkLocation,
             child: const Text('RETRY'),
           ),

--- a/lib/screens/region_draw/region_draw_screen.dart
+++ b/lib/screens/region_draw/region_draw_screen.dart
@@ -148,7 +148,7 @@ class _RegionDrawScreenState extends ConsumerState<RegionDrawScreen> {
       builder: (dialogContext) => AlertDialog(
         title: const Text('Name this area'),
         content: TextField(
-          key: const ValueKey('region_name_field'),
+          key: const ValueKey<String>('regionDrawNameInput1'),
           controller: controller,
           autofocus: true,
           decoration: const InputDecoration(hintText: 'e.g. Orange Circle'),
@@ -159,7 +159,7 @@ class _RegionDrawScreenState extends ConsumerState<RegionDrawScreen> {
             child: const Text('Cancel'),
           ),
           FilledButton(
-            key: const ValueKey('region_save_confirm'),
+            key: const ValueKey<String>('regionDrawSaveConfirmBtn1'),
             onPressed: () => Navigator.pop(dialogContext, controller.text),
             child: const Text('Save'),
           ),
@@ -190,7 +190,7 @@ class _RegionDrawScreenState extends ConsumerState<RegionDrawScreen> {
           AnimatedBuilder(
             animation: _draw,
             builder: (context, _) => TextButton(
-              key: const ValueKey('region_save_button'),
+              key: const ValueKey<String>('regionDrawSaveBtn1'),
               onPressed: _draw.canSave && !_drawMode ? _save : null,
               child: const Text('Save'),
             ),
@@ -231,7 +231,7 @@ class _RegionDrawScreenState extends ConsumerState<RegionDrawScreen> {
         ),
       ),
       floatingActionButton: FloatingActionButton.extended(
-        key: const ValueKey('region_draw_fab'),
+        key: const ValueKey<String>('regionDrawDrawBtn1'),
         onPressed: _toggleDrawMode,
         backgroundColor: _drawMode ? GoogieColors.chrome : GoogieColors.coral,
         icon: Icon(_drawMode ? Icons.close : Icons.gesture),

--- a/lib/screens/results/results_screen.dart
+++ b/lib/screens/results/results_screen.dart
@@ -71,15 +71,18 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
       builder: (dialogContext) => AlertDialog(
         title: const Text('Rename area'),
         content: TextField(
+          key: const ValueKey('resultsRenameAreaInput1'),
           controller: controller,
           autofocus: true,
         ),
         actions: [
           TextButton(
+            key: const ValueKey('resultsRenameAreaCancelBtn1'),
             onPressed: () => Navigator.pop(dialogContext),
             child: const Text('Cancel'),
           ),
           FilledButton(
+            key: const ValueKey('resultsRenameAreaSaveBtn1'),
             onPressed: () => Navigator.pop(dialogContext, controller.text),
             child: const Text('Save'),
           ),
@@ -127,7 +130,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             TextField(
-              key: const ValueKey('spot_name_field'),
+              key: const ValueKey('resultsSpotNameInput1'),
               controller: controller,
               autofocus: true,
               decoration: const InputDecoration(labelText: 'Name'),
@@ -140,11 +143,12 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
         ),
         actions: [
           TextButton(
+            key: const ValueKey('resultsSpotSaveCancelBtn1'),
             onPressed: () => Navigator.pop(dialogContext),
             child: const Text('Cancel'),
           ),
           FilledButton(
-            key: const ValueKey('spot_save_confirm'),
+            key: const ValueKey('resultsSpotSaveConfirmBtn1'),
             onPressed: () => Navigator.pop(dialogContext, controller.text),
             child: const Text('Save'),
           ),
@@ -294,7 +298,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
                         children: [
                           for (final level in const [1, 2, 3])
                             ChoiceChip(
-                              key: ValueKey('tune_price_$level'),
+                              key: ValueKey('resultsTunePriceChip_$level'),
                               label: Text(r'$' * level),
                               selected: filters.priceLevels.contains(level),
                               showCheckmark: true,
@@ -392,7 +396,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
                     identifier: 'spin_button',
                     button: true,
                     child: RandoEatsButton(
-                      key: const ValueKey('spin_button'),
+                      key: const ValueKey('resultsSpinBtn1'),
                       // Locked for the whole winner sequence: the reel spin
                       // (status == spinning) through the reveal + celebration,
                       // re-enabled only once the celebration completes.
@@ -455,7 +459,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
             ),
           ),
           TextButton(
-            key: const ValueKey('notice_show_all'),
+            key: const ValueKey('resultsNoticeShowAllBtn1'),
             onPressed: _showAllRestaurants,
             style: TextButton.styleFrom(
               foregroundColor: GoogieColors.onMustardContainer,
@@ -465,7 +469,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
             child: const Text('Show all'),
           ),
           IconButton(
-            key: const ValueKey('notice_dismiss'),
+            key: const ValueKey('resultsNoticeDismissBtn1'),
             icon: const Icon(Icons.close, size: 18),
             color: GoogieColors.onMustardContainer,
             visualDensity: VisualDensity.compact,
@@ -486,6 +490,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
           // Refresh button (left side)
           if (canRefresh)
             IconButton(
+              key: const ValueKey('resultsRefreshBtn1'),
               icon: const Icon(Icons.refresh),
               color: GoogieColors.deepTeal,
               iconSize: 28,
@@ -496,7 +501,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
           // spin too (the refresh button hides then, the count shouldn't).
           if (count > 0)
             Container(
-              key: const ValueKey('result_count'),
+              key: const ValueKey('resultsResultCountText1'),
               padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
               decoration: BoxDecoration(
                 color: GoogieColors.turquoiseContainer,
@@ -513,7 +518,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
           const Spacer(),
           // Quick tune (radius + price) in an M3 bottom sheet.
           IconButton(
-            key: const ValueKey('quick_tune_button'),
+            key: const ValueKey('resultsQuickTuneBtn1'),
             icon: const Icon(Icons.tune),
             color: GoogieColors.deepTeal,
             iconSize: 26,
@@ -522,7 +527,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
           ),
           // About (info) — sits between the filters tune and the gear.
           IconButton(
-            key: const ValueKey('about_button'),
+            key: const ValueKey('resultsAboutBtn1'),
             icon: const Icon(Icons.info_outline),
             color: GoogieColors.deepTeal,
             iconSize: 26,
@@ -536,6 +541,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
             identifier: 'settings_button',
             button: true,
             child: IconButton(
+              key: const ValueKey('resultsSettingsBtn1'),
               icon: const Icon(Icons.settings),
               color: GoogieColors.deepTeal,
               iconSize: 28,
@@ -622,6 +628,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
             const SizedBox(height: 8),
             Text(
               message,
+              key: const ValueKey('resultsErrorText1'),
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
               ),
@@ -629,6 +636,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
             ),
             const SizedBox(height: 24),
             ElevatedButton.icon(
+              key: const ValueKey('resultsTryAgainBtn1'),
               onPressed: () {
                 unawaited(ref.read(discoveryProvider.notifier).start());
               },

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -191,7 +191,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ? 'Reduced motion — winner revealed without spinning'
                 : 'Full slot-machine spin animation',
             child: Switch(
-              key: const ValueKey('setting_calm_mode'),
+              key: const ValueKey<String>('settingsCalmModeToggle1'),
               value: _settings.calmMode,
               activeTrackColor: GoogieColors.turquoise,
               onChanged: (value) {
@@ -299,7 +299,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   }) {
     final p = appTheme.palette;
     return GestureDetector(
-      key: ValueKey('theme_swatch_${appTheme.id}'),
+      key: ValueKey<String>('settingsThemeSwatch_${appTheme.id}'),
       onTap: () => ref.read(themeProvider.notifier).select(appTheme),
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 200),

--- a/lib/screens/splash/splash_screen.dart
+++ b/lib/screens/splash/splash_screen.dart
@@ -70,6 +70,7 @@ class _SplashScreenState extends State<SplashScreen>
             scale: _scale,
             child: Image.asset(
               'assets/images/splash_logo.png',
+              key: const ValueKey<String>('splashLogoImg1'),
               width: logoWidth,
             ),
           ),

--- a/lib/widgets/filter_chip_bar.dart
+++ b/lib/widgets/filter_chip_bar.dart
@@ -44,14 +44,14 @@ class FilterChipBar extends ConsumerWidget {
                 children: [
                   for (final c in _cuisines)
                     _FacetChip(
-                      key: ValueKey('filter_cuisine_${c.code}'),
+                      key: ValueKey('resultsCuisineChip_${c.code}'),
                       label: c.label,
                       icon: c.icon,
                       selected: filters.cuisines.contains(c.code),
                       onToggle: () => notifier.toggleCuisine(c.code),
                     ),
                   _FacetChip(
-                    key: const ValueKey('filter_beer'),
+                    key: const ValueKey('resultsFilterBeerTap1'),
                     label: 'Beer',
                     icon: Icons.sports_bar,
                     selected: filters.servesBeer,
@@ -60,7 +60,7 @@ class FilterChipBar extends ConsumerWidget {
                     ),
                   ),
                   _FacetChip(
-                    key: const ValueKey('filter_wine'),
+                    key: const ValueKey('resultsFilterWineTap1'),
                     label: 'Wine',
                     icon: Icons.wine_bar,
                     selected: filters.servesWine,
@@ -69,7 +69,7 @@ class FilterChipBar extends ConsumerWidget {
                     ),
                   ),
                   _FacetChip(
-                    key: const ValueKey('filter_patio'),
+                    key: const ValueKey('resultsFilterPatioTap1'),
                     label: 'Patio',
                     icon: Icons.deck,
                     selected: filters.outdoorSeating,
@@ -78,7 +78,7 @@ class FilterChipBar extends ConsumerWidget {
                     ),
                   ),
                   _FacetChip(
-                    key: const ValueKey('filter_parking'),
+                    key: const ValueKey('resultsFilterParkingTap1'),
                     label: 'Parking',
                     icon: Icons.local_parking,
                     selected: filters.hasParking,
@@ -87,7 +87,7 @@ class FilterChipBar extends ConsumerWidget {
                     ),
                   ),
                   _FacetChip(
-                    key: const ValueKey('filter_group'),
+                    key: const ValueKey('resultsFilterGroupTap1'),
                     label: 'Group',
                     icon: Icons.groups,
                     selected: filters.goodForGroups,
@@ -96,7 +96,7 @@ class FilterChipBar extends ConsumerWidget {
                     ),
                   ),
                   _FacetChip(
-                    key: const ValueKey('filter_open'),
+                    key: const ValueKey('resultsFilterOpenTap1'),
                     label: 'Open',
                     icon: Icons.schedule,
                     selected: filters.openNow,
@@ -104,7 +104,7 @@ class FilterChipBar extends ConsumerWidget {
                         notifier.update((f) => f.copyWith(openNow: !f.openNow)),
                   ),
                   _FacetChip(
-                    key: const ValueKey('filter_rating'),
+                    key: const ValueKey('resultsFilterRatingTap1'),
                     label: '4.0+',
                     icon: Icons.star,
                     selected: filters.minRating != null,
@@ -116,7 +116,7 @@ class FilterChipBar extends ConsumerWidget {
                   ),
                   for (final level in const [1, 2, 3])
                     _FacetChip(
-                      key: ValueKey('filter_price_$level'),
+                      key: ValueKey('resultsPriceChip_$level'),
                       label: r'$' * level,
                       selected: filters.priceLevels.contains(level),
                       onToggle: () => notifier.togglePriceLevel(level),
@@ -132,7 +132,7 @@ class FilterChipBar extends ConsumerWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
               child: ActionChip(
-                key: const ValueKey('filter_clear_all'),
+                key: const ValueKey('resultsClearAllTap1'),
                 avatar: Icon(
                   Icons.filter_alt_off,
                   size: 18,
@@ -154,7 +154,7 @@ class FilterChipBar extends ConsumerWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
               child: ActionChip(
-                key: const ValueKey('filter_save_spot'),
+                key: const ValueKey('resultsSaveSpotTap1'),
                 avatar: Icon(
                   Icons.star,
                   size: 18,

--- a/lib/widgets/multi_reel_slot_machine.dart
+++ b/lib/widgets/multi_reel_slot_machine.dart
@@ -383,7 +383,7 @@ class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
           borderRadius: BorderRadius.circular(12),
         ),
         child: ListView.builder(
-          key: const ValueKey('reel_list'),
+          key: const ValueKey('resultsReelList1'),
           controller: _scroll,
           physics: widget.spinning
               ? const NeverScrollableScrollPhysics()
@@ -410,7 +410,7 @@ class _ReelState extends State<_Reel> with SingleTickerProviderStateMixin {
                 widget.detailBuilder != null;
 
             RestaurantCard cardWith(VoidCallback onTap) => RestaurantCard(
-              key: ValueKey('reel_cell_${restaurant.placeId}_$index'),
+              key: ValueKey('resultsReelCell_${restaurant.placeId}_$index'),
               restaurant: restaurant,
               index: index,
               // Only the unique winning cell anchors the Hero flight into

--- a/lib/widgets/region_chip_bar.dart
+++ b/lib/widgets/region_chip_bar.dart
@@ -52,7 +52,7 @@ class RegionChipBar extends ConsumerWidget {
                 padding: const EdgeInsets.only(left: 4, right: 16),
                 children: [
                   _ScopeChip(
-                    key: const ValueKey('region_chip_near_me'),
+                    key: const ValueKey('resultsRegionNearMeTap1'),
                     label: 'Near Me',
                     icon: Icons.my_location,
                     selected: active == null,
@@ -60,7 +60,7 @@ class RegionChipBar extends ConsumerWidget {
                   ),
                   for (final region in regions)
                     _ScopeChip(
-                      key: ValueKey('region_chip_${region.id}'),
+                      key: ValueKey('resultsRegionChip_${region.id}'),
                       label: region.name,
                       icon: Icons.place,
                       selected: active?.id == region.id,
@@ -74,7 +74,7 @@ class RegionChipBar extends ConsumerWidget {
                       onLongPress: () => _showRegionMenu(context, region),
                     ),
                   _ScopeChip(
-                    key: const ValueKey('region_chip_add'),
+                    key: const ValueKey('resultsRegionAddTap1'),
                     label: 'New Area',
                     icon: Icons.add,
                     selected: false,
@@ -97,13 +97,13 @@ class RegionChipBar extends ConsumerWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             ListTile(
-              key: const ValueKey('region_menu_rename'),
+              key: const ValueKey('resultsRegionMenuRenameTap1'),
               leading: Icon(Icons.edit, color: GoogieColors.deepTeal),
               title: const Text('Rename'),
               onTap: () => Navigator.pop(sheetContext, _RegionAction.rename),
             ),
             ListTile(
-              key: const ValueKey('region_menu_delete'),
+              key: const ValueKey('resultsRegionMenuDeleteTap1'),
               leading: Icon(Icons.delete, color: GoogieColors.coral),
               title: const Text('Delete'),
               onTap: () => Navigator.pop(sheetContext, _RegionAction.delete),

--- a/lib/widgets/restaurant_directions_sheet.dart
+++ b/lib/widgets/restaurant_directions_sheet.dart
@@ -150,6 +150,7 @@ class _RestaurantDirectionsSheetState extends State<RestaurantDirectionsSheet> {
     final theme = Theme.of(context);
 
     return SizedBox(
+      key: const ValueKey('restaurantDetailDirectionsSheet1'),
       height: 0.85 * MediaQuery.of(context).size.height,
       child: Column(
         children: [
@@ -166,7 +167,7 @@ class _RestaurantDirectionsSheetState extends State<RestaurantDirectionsSheet> {
                   ),
                 ),
                 IconButton(
-                  key: const ValueKey('directions_close'),
+                  key: const ValueKey('restaurantDetailCloseBtn1'),
                   icon: const Icon(Icons.close),
                   tooltip: 'Close',
                   onPressed: () => Navigator.pop(context),
@@ -174,7 +175,12 @@ class _RestaurantDirectionsSheetState extends State<RestaurantDirectionsSheet> {
               ],
             ),
           ),
-          Expanded(child: WebViewWidget(controller: _controller)),
+          Expanded(
+            child: WebViewWidget(
+              key: const ValueKey('restaurantDetailDirectionsMap1'),
+              controller: _controller,
+            ),
+          ),
           SafeArea(
             top: false,
             child: Padding(
@@ -182,7 +188,7 @@ class _RestaurantDirectionsSheetState extends State<RestaurantDirectionsSheet> {
               child: SizedBox(
                 width: double.infinity,
                 child: TextButton.icon(
-                  key: const ValueKey('directions_open_external'),
+                  key: const ValueKey('restaurantDetailOpenExternalBtn1'),
                   onPressed: _openInGoogleMaps,
                   icon: const Icon(Icons.open_in_new),
                   label: const Text('Open in Google Maps'),

--- a/test/screens/detail_screen_render_test.dart
+++ b/test/screens/detail_screen_render_test.dart
@@ -68,9 +68,12 @@ void main() {
     expect(find.text('Test Diner'), findsOneWidget);
     expect(find.text('Directions'), findsOneWidget);
     // Rating buttons are icon-only now (no "Good Pick!" / "Not For Me" text).
-    expect(find.byKey(const ValueKey('detail_rate_thumbsUp')), findsOneWidget);
     expect(
-      find.byKey(const ValueKey('detail_rate_thumbsDown')),
+      find.byKey(const ValueKey('restaurantDetailRatethumbsUpBtn1')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('restaurantDetailRatethumbsDownBtn1')),
       findsOneWidget,
     );
   });
@@ -82,7 +85,10 @@ void main() {
     await pumpDetail(tester, const Size(1024, 1366));
     expect(tester.takeException(), isNull);
     expect(find.text('Directions'), findsOneWidget);
-    expect(find.byKey(const ValueKey('detail_rate_thumbsUp')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('restaurantDetailRatethumbsUpBtn1')),
+      findsOneWidget,
+    );
     handle.dispose();
   });
 
@@ -111,22 +117,34 @@ void main() {
       ),
     );
     await tester.pump();
-    expect(find.byKey(const ValueKey('detail_call')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('restaurantDetailCallTap1')),
+      findsOneWidget,
+    );
     expect(find.text('(415) 555-0123'), findsOneWidget);
   });
 
   testWidgets('hides the phone row when no number is present', (tester) async {
     // The module-level `restaurant` has no phoneNumber.
     await pumpDetail(tester, const Size(390, 844));
-    expect(find.byKey(const ValueKey('detail_call')), findsNothing);
+    expect(
+      find.byKey(const ValueKey('restaurantDetailCallTap1')),
+      findsNothing,
+    );
   });
 
   testWidgets('Directions is the only action; Abort Mission is gone', (
     tester,
   ) async {
     await pumpDetail(tester, const Size(390, 844));
-    expect(find.byKey(const ValueKey('detail_navigate')), findsOneWidget);
-    expect(find.byKey(const ValueKey('detail_abort')), findsNothing);
+    expect(
+      find.byKey(const ValueKey('restaurantDetailNavigateBtn1')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('restaurantDetailAbortBtn1')),
+      findsNothing,
+    );
   });
 
   testWidgets('renders wide + scrollable with semantics (no infinite width)', (

--- a/test/widgets/filter_chip_bar_test.dart
+++ b/test/widgets/filter_chip_bar_test.dart
@@ -38,34 +38,36 @@ void main() {
 
     testWidgets('tapping Beer toggles servesBeer', (tester) async {
       final container = await pump(tester);
-      await tester.tap(find.byKey(const ValueKey('filter_beer')));
+      await tester.tap(find.byKey(const ValueKey('resultsFilterBeerTap1')));
       await tester.pump();
       expect(container.read(activeFiltersProvider).servesBeer, isTrue);
-      await tester.tap(find.byKey(const ValueKey('filter_beer')));
+      await tester.tap(find.byKey(const ValueKey('resultsFilterBeerTap1')));
       await tester.pump();
       expect(container.read(activeFiltersProvider).servesBeer, isFalse);
     });
 
     testWidgets('tapping Mexican toggles the cuisine', (tester) async {
       final container = await pump(tester);
-      await tester.tap(find.byKey(const ValueKey('filter_cuisine_mexican')));
+      await tester.tap(
+        find.byKey(const ValueKey('resultsCuisineChip_mexican')),
+      );
       await tester.pump();
       expect(container.read(activeFiltersProvider).cuisines, {'mexican'});
     });
 
     testWidgets('tapping 4.0+ sets then clears minRating', (tester) async {
       final container = await pump(tester);
-      await tester.tap(find.byKey(const ValueKey('filter_rating')));
+      await tester.tap(find.byKey(const ValueKey('resultsFilterRatingTap1')));
       await tester.pump();
       expect(container.read(activeFiltersProvider).minRating, 4.0);
-      await tester.tap(find.byKey(const ValueKey('filter_rating')));
+      await tester.tap(find.byKey(const ValueKey('resultsFilterRatingTap1')));
       await tester.pump();
       expect(container.read(activeFiltersProvider).minRating, isNull);
     });
 
     testWidgets('tapping a price chip toggles the level', (tester) async {
       final container = await pump(tester);
-      await tester.tap(find.byKey(const ValueKey('filter_price_2')));
+      await tester.tap(find.byKey(const ValueKey('resultsPriceChip_2')));
       await tester.pump();
       expect(container.read(activeFiltersProvider).priceLevels, {2});
     });
@@ -74,14 +76,14 @@ void main() {
       final container = await pump(tester);
       container.read(activeFiltersProvider.notifier).toggleCuisine('mexican');
       await tester.pump();
-      expect(find.byKey(const ValueKey('filter_save_spot')), findsNothing);
+      expect(find.byKey(const ValueKey('resultsSaveSpotTap1')), findsNothing);
     });
 
     testWidgets('save-spot star is hidden when no filters are active', (
       tester,
     ) async {
       await pump(tester, onSaveSpot: () {});
-      expect(find.byKey(const ValueKey('filter_save_spot')), findsNothing);
+      expect(find.byKey(const ValueKey('resultsSaveSpotTap1')), findsNothing);
     });
 
     testWidgets('save-spot star appears and fires when filters active', (
@@ -89,13 +91,13 @@ void main() {
     ) async {
       var saved = false;
       final container = await pump(tester, onSaveSpot: () => saved = true);
-      expect(find.byKey(const ValueKey('filter_save_spot')), findsNothing);
+      expect(find.byKey(const ValueKey('resultsSaveSpotTap1')), findsNothing);
 
       container.read(activeFiltersProvider.notifier).toggleCuisine('mexican');
       await tester.pump();
 
-      expect(find.byKey(const ValueKey('filter_save_spot')), findsOneWidget);
-      await tester.tap(find.byKey(const ValueKey('filter_save_spot')));
+      expect(find.byKey(const ValueKey('resultsSaveSpotTap1')), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('resultsSaveSpotTap1')));
       await tester.pump();
       expect(saved, isTrue);
     });

--- a/test/widgets/region_chip_bar_test.dart
+++ b/test/widgets/region_chip_bar_test.dart
@@ -55,7 +55,7 @@ void main() {
       await pumpBar(tester);
       final chip = tester.widget<ChoiceChip>(
         find.descendant(
-          of: find.byKey(const ValueKey('region_chip_near_me')),
+          of: find.byKey(const ValueKey('resultsRegionNearMeTap1')),
           matching: find.byType(ChoiceChip),
         ),
       );
@@ -64,7 +64,7 @@ void main() {
 
     testWidgets('tapping a region chip activates it', (tester) async {
       final container = await pumpBar(tester);
-      await tester.tap(find.byKey(const ValueKey('region_chip_r1')));
+      await tester.tap(find.byKey(const ValueKey('resultsRegionChip_r1')));
       await tester.pump();
       expect(container.read(activeRegionProvider)?.id, 'r1');
     });
@@ -92,7 +92,7 @@ void main() {
           ),
         ),
       );
-      await tester.tap(find.byKey(const ValueKey('region_chip_s1')));
+      await tester.tap(find.byKey(const ValueKey('resultsRegionChip_s1')));
       await tester.pump();
       expect(container.read(activeRegionProvider)?.id, 's1');
       expect(container.read(activeFiltersProvider).servesBeer, isTrue);
@@ -104,7 +104,7 @@ void main() {
       container.read(activeRegionProvider.notifier).select(regions.first);
       await tester.pump();
 
-      await tester.tap(find.byKey(const ValueKey('region_chip_near_me')));
+      await tester.tap(find.byKey(const ValueKey('resultsRegionNearMeTap1')));
       await tester.pump();
       expect(container.read(activeRegionProvider), isNull);
     });
@@ -112,7 +112,7 @@ void main() {
     testWidgets('tapping New Area invokes onCreate', (tester) async {
       var created = false;
       await pumpBar(tester, onCreate: () => created = true);
-      await tester.tap(find.byKey(const ValueKey('region_chip_add')));
+      await tester.tap(find.byKey(const ValueKey('resultsRegionAddTap1')));
       await tester.pump();
       expect(created, isTrue);
     });
@@ -121,9 +121,13 @@ void main() {
       SavedRegion? deleted;
       await pumpBar(tester, onDelete: (r) => deleted = r);
 
-      await tester.longPress(find.byKey(const ValueKey('region_chip_r1')));
+      await tester.longPress(
+        find.byKey(const ValueKey('resultsRegionChip_r1')),
+      );
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('region_menu_delete')));
+      await tester.tap(
+        find.byKey(const ValueKey('resultsRegionMenuDeleteTap1')),
+      );
       await tester.pumpAndSettle();
 
       expect(deleted?.id, 'r1');
@@ -133,9 +137,13 @@ void main() {
       SavedRegion? renamed;
       await pumpBar(tester, onRename: (r) => renamed = r);
 
-      await tester.longPress(find.byKey(const ValueKey('region_chip_r2')));
+      await tester.longPress(
+        find.byKey(const ValueKey('resultsRegionChip_r2')),
+      );
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('region_menu_rename')));
+      await tester.tap(
+        find.byKey(const ValueKey('resultsRegionMenuRenameTap1')),
+      );
       await tester.pumpAndSettle();
 
       expect(renamed?.id, 'r2');


### PR DESCRIPTION
Migrates every widget `Key` across the screens (and their single-screen widgets) from the old snake_case scheme to a consistent camelCase `<screenPrefix><SemanticName><TypeSuffix><N>` convention, and adds keys to interactive/meaningful widgets that were missing them.

## What changed
- **71 keys** set across 7 screens — 44 renamed to the new convention, 27 newly added.
- Loop items (cuisine/price/region chips, reel cells, theme swatches, photos) keep their dynamic identity so specific items stay targetable.
- Test references updated to the new keys.
- New reference doc **`docs/WIDGET_KEYS.md`** — the convention + full old→new key map + decisions.

## Testing
- `flutter analyze --fatal-infos --fatal-warnings` — clean
- `flutter test` — **337 passing**

## Known gap (tracked separately)
Settings sliders / action buttons / unit toggles / category chips are built by shared helper methods called multiple times; keying inline would create duplicate keys. Full coverage needs the helpers parameterized with a per-call key.