### PR TITLE
feat(settings): key all interactive settings widgets

### DIFF
--- a/docs/WIDGET_KEYS.md
+++ b/docs/WIDGET_KEYS.md
@@ -75,8 +75,26 @@ list/carousel.
 
 | Widget | Old key | New key |
 |---|---|---|
-| Switch (calm mode) | `setting_calm_mode` | `settingsCalmModeToggle1` |
 | GestureDetector (theme swatch, loop) | `theme_swatch_${appTheme.id}` | `settingsThemeSwatch_${appTheme.id}` |
+| GestureDetector (distance unit — miles) | — | `settingsUnitMilesTap1` |
+| GestureDetector (distance unit — km) | — | `settingsUnitKilometersTap1` |
+| Slider (search radius) | — | `settingsSearchRadiusSlider1` |
+| Slider (max results) | — | `settingsMaxResultsSlider1` |
+| Slider (hide days) | — | `settingsHideDaysSlider1` |
+| Switch (open only) | — | `settingsOpenOnlyToggle1` |
+| Switch (calm mode) | `setting_calm_mode` | `settingsCalmModeToggle1` |
+| GestureDetector (category chip, loop) | — | `settingsCategoryChip_${category.code}` |
+| OutlinedButton (clear visit history) | — | `settingsClearVisitHistoryBtn1` |
+| OutlinedButton (clear recent picks) | — | `settingsClearRecentPicksBtn1` |
+| OutlinedButton (clear all data) | — | `settingsClearAllDataBtn1` |
+| TextButton (visit-history dialog cancel/confirm) | — | `settingsClearVisitHistory{Cancel,Confirm}Btn1` |
+| TextButton (recent-picks dialog cancel/confirm) | — | `settingsClearRecentPicks{Cancel,Confirm}Btn1` |
+| TextButton (all-data dialog cancel/confirm) | — | `settingsClearAllData{Cancel,Confirm}Btn1` |
+
+> `Slider` uses the suffix `Slider` (an extension of the type table below,
+> which has no entry for sliders). Settings widgets built by the shared
+> helpers (`_buildUnitOption`, `_buildCategoryChip`, `_buildActionButton`) are
+> keyed by threading a `Key?` argument through the helper to each call site.
 
 ### regionDraw (`RegionDrawScreen`)
 
@@ -167,10 +185,9 @@ list/carousel.
 
 ## Known gaps (follow-up)
 
-- **Settings** sliders, action buttons, unit toggles, and category chips are
-  built by shared helper methods called multiple times; keying inside would
-  create duplicate keys. Full coverage needs the helpers parameterized with a
-  per-call key.
-- **Quick-tune `Slider`** — no `Slider` suffix defined in the convention.
+- **Quick-tune `Slider`** (results quick-tune sheet) — not yet keyed.
 - **`restaurant_map_sheet.dart`** (`restaurant_map_close`) — orphaned (the
   directions sheet replaced it), left on its old key; out of screen scope.
+
+_(The settings helper-method coverage gap was resolved — see the settings
+table above.)_

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -129,6 +129,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             title: 'Search Radius',
             subtitle: _formatDistance(_settings.searchRadiusMeters),
             child: Slider(
+              key: const ValueKey<String>('settingsSearchRadiusSlider1'),
               value: _settings.searchRadiusMeters.toDouble(),
               min: UserSettings.minSearchRadius.toDouble(),
               max: UserSettings.maxSearchRadius.toDouble(),
@@ -149,6 +150,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             title: 'Maximum Results',
             subtitle: '${_settings.maxResults} restaurants',
             child: Slider(
+              key: const ValueKey<String>('settingsMaxResultsSlider1'),
               value: _settings.maxResults.toDouble(),
               min: UserSettings.minMaxResults.toDouble(),
               max: UserSettings.maxMaxResults.toDouble(),
@@ -172,6 +174,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ? 'Only showing open restaurants'
                 : 'Showing all restaurants',
             child: Switch(
+              key: const ValueKey<String>('settingsOpenOnlyToggle1'),
               value: _settings.includeOpenOnly,
               activeTrackColor: GoogieColors.turquoise,
               onChanged: (value) {
@@ -230,6 +233,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             description:
                 'Restaurants you pick will be hidden for this many days.',
             child: Slider(
+              key: const ValueKey<String>('settingsHideDaysSlider1'),
               value: _settings.hideDaysAfterPick.toDouble(),
               min: UserSettings.minHideDays.toDouble(),
               max: UserSettings.maxHideDays.toDouble(),
@@ -251,6 +255,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
           _buildActionButton(
             theme,
+            key: const ValueKey<String>('settingsClearVisitHistoryBtn1'),
             title: 'Clear Visit History',
             subtitle: 'Reset all visit counts to zero',
             icon: Icons.history,
@@ -260,6 +265,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
           _buildActionButton(
             theme,
+            key: const ValueKey<String>('settingsClearRecentPicksBtn1'),
             title: 'Clear Recent Picks',
             subtitle: 'Show all previously picked restaurants again',
             icon: Icons.refresh,
@@ -269,6 +275,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
           _buildActionButton(
             theme,
+            key: const ValueKey<String>('settingsClearAllDataBtn1'),
             title: 'Clear All Data',
             subtitle: 'Reset everything including ratings',
             icon: Icons.delete_forever,
@@ -377,6 +384,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           Expanded(
             child: _buildUnitOption(
               theme,
+              key: const ValueKey<String>('settingsUnitMilesTap1'),
               label: 'Miles',
               isSelected: _settings.distanceUnit == DistanceUnit.miles,
               onTap: () => _updateSettings(
@@ -387,6 +395,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           Expanded(
             child: _buildUnitOption(
               theme,
+              key: const ValueKey<String>('settingsUnitKilometersTap1'),
               label: 'Kilometers',
               isSelected: _settings.distanceUnit == DistanceUnit.kilometers,
               onTap: () => _updateSettings(
@@ -404,8 +413,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     required String label,
     required bool isSelected,
     required VoidCallback onTap,
+    Key? key,
   }) {
     return GestureDetector(
+      key: key,
       onTap: onTap,
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 200),
@@ -436,6 +447,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         final isBanned = _settings.bannedCategories.contains(entry.key);
         return _buildCategoryChip(
           theme,
+          key: ValueKey<String>('settingsCategoryChip_${entry.key}'),
           label: entry.value,
           isBanned: isBanned,
           onTap: () => _toggleCategory(entry.key),
@@ -449,8 +461,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     required String label,
     required bool isBanned,
     required VoidCallback onTap,
+    Key? key,
   }) {
     return GestureDetector(
+      key: key,
       onTap: onTap,
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 200),
@@ -562,9 +576,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     required IconData icon,
     required VoidCallback onPressed,
     Color? color,
+    Key? key,
   }) {
     final buttonColor = color ?? GoogieColors.turquoise;
     return OutlinedButton(
+      key: key,
       onPressed: onPressed,
       style: OutlinedButton.styleFrom(
         foregroundColor: buttonColor,
@@ -618,10 +634,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         ),
         actions: [
           TextButton(
+            key: const ValueKey<String>('settingsClearVisitHistoryCancelBtn1'),
             onPressed: () => Navigator.of(context).pop(false),
             child: const Text('CANCEL'),
           ),
           TextButton(
+            key: const ValueKey<String>(
+              'settingsClearVisitHistoryConfirmBtn1',
+            ),
             onPressed: () => Navigator.of(context).pop(true),
             child: Text(
               'CLEAR',
@@ -655,10 +675,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         ),
         actions: [
           TextButton(
+            key: const ValueKey<String>('settingsClearRecentPicksCancelBtn1'),
             onPressed: () => Navigator.of(context).pop(false),
             child: const Text('CANCEL'),
           ),
           TextButton(
+            key: const ValueKey<String>('settingsClearRecentPicksConfirmBtn1'),
             onPressed: () => Navigator.of(context).pop(true),
             child: Text(
               'CLEAR',
@@ -692,10 +714,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         ),
         actions: [
           TextButton(
+            key: const ValueKey<String>('settingsClearAllDataCancelBtn1'),
             onPressed: () => Navigator.of(context).pop(false),
             child: const Text('CANCEL'),
           ),
           TextButton(
+            key: const ValueKey<String>('settingsClearAllDataConfirmBtn1'),
             onPressed: () => Navigator.of(context).pop(true),
             child: Text(
               'DELETE ALL',


### PR DESCRIPTION
Closes #82.

Completes widget-key coverage on the Settings screen — the one gap left by the convention refactor (#81).

## What changed
- **Sliders** (search radius, max results, hide days), the **open-only** and **calm-mode** switches, the **distance-unit** options, the **category chips**, the three **data-management** action buttons, and their **confirm dialogs** all now carry `ValueKey`s following `<settings><SemanticName><TypeSuffix><N>`.
- The shared helpers (`_buildUnitOption`, `_buildCategoryChip`, `_buildActionButton`) take an optional `Key?` threaded to each call site, so multiply-called helpers no longer collide.
- `docs/WIDGET_KEYS.md` updated; settings removed from Known gaps.

## Testing
- `flutter analyze --fatal-infos --fatal-warnings` — clean
- `flutter test` — **337 passing**