### PR TITLE
fix(bff): do not build tests in the deployable image

### DIFF
--- a/bff/CMakeLists.txt
+++ b/bff/CMakeLists.txt
@@ -28,6 +28,14 @@ target_link_libraries(randoeats_bff_lib PUBLIC Drogon::Drogon)
 add_executable(randoeats_bff main.cc)
 target_link_libraries(randoeats_bff PRIVATE randoeats_bff_lib)
 
+# The deployable image's build context copies only CMakeLists.txt, main.cc,
+# controllers/ and services/ -- it has no tests/ directory, and no reason to
+# build tests. Default ON so a normal checkout gets the suite; bff/Dockerfile
+# passes -DBUILD_TESTS=OFF.
+option(BUILD_TESTS "Build the unit tests" ON)
+
+if(BUILD_TESTS)
+
 enable_testing()
 
 add_executable(randoeats_bff_tests
@@ -49,3 +57,5 @@ if(ENABLE_SANITIZERS)
 endif()
 
 add_test(NAME randoeats_bff_tests COMMAND randoeats_bff_tests)
+
+endif()

--- a/bff/Dockerfile
+++ b/bff/Dockerfile
@@ -11,7 +11,8 @@ WORKDIR /src
 COPY CMakeLists.txt main.cc ./
 COPY controllers/ controllers/
 COPY services/ services/
-RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
+# This context has no tests/ -- the image ships the binary only.
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF && \
     cmake --build build -j"$(nproc)"
 
 FROM drogonframework/drogon:latest AS runtime


### PR DESCRIPTION
## Description

Regression from #90, currently red on `main`.

The library/executable split added a `randoeats_bff_tests` target unconditionally. `bff/Dockerfile`'s build context copies only `CMakeLists.txt`, `main.cc`, `controllers/` and `services/` — there is no `tests/` directory in it — so CMake failed at generate time:

```
CMake Error at CMakeLists.txt:33 (add_executable):
  Cannot find source file:
    tests/test_main.cc
```

**How it got through:** #90 was verified against `just check` and the `check` workflow. Neither builds the container image, so a fully green PR still broke the deployable artifact.

## Fix

Guard the test target behind `BUILD_TESTS`, defaulting ON so a normal checkout gets the suite, and have the Dockerfile pass `-DBUILD_TESTS=OFF` explicitly rather than relying on a directory happening to be absent.

## Verification

- Configured a copy of the real Docker build context — `CMakeLists.txt`, `main.cc`, `controllers/`, `services/`, **no `tests/`** — with the Dockerfile's exact flags. Configures and generates cleanly.
- `just check` green: 346 Dart tests, tidy ratchet at 112, 17 BFF tests.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9tP61i71QHPPPSL8z6dZe