### PR TITLE
chore: retire BACKLOG.adoc; GitHub Issues is the single backlog (ADR-0005)

### DIFF
--- a/BACKLOG.adoc
+++ b/BACKLOG.adoc
@@ -1,130 +1,14 @@
 = Backlog
-:toc: left
 
 [.lead]
-The roadmap, as a document that travels with the repo. Bugs are events and
-live in GitHub Issues, where they link to commits and close automatically —
-this file is for the roadmap only: things that are planned but not yet
-tracked as discrete, closeable work items.
+The backlog lives in GitHub Issues:
+https://github.com/Rockncoder/randoeats/issues
 
-// Seeded during the template migration (see MIGRATION-NOTES.adoc) from
-// docs/legacy/MVP_PLAN.md, docs/legacy-CLAUDE.md's phase list, and
-// docs/legacy/BACKEND_PROXY_PLAN.md, plus every convention gap and every red
-// `just check` ring found during the migration. Both source documents were
-// stale — items they listed as open but that the code shows are DONE were
-// dropped rather than copied. See MIGRATION-NOTES.adoc for which.
+Priority is expressed with labels — `priority:now`, `priority:next`,
+`priority:later`. Work that has been decided against is filed and closed as
+`wontfix`, so the reasoning stays searchable without sitting in the open list.
 
-== Now
-
-* Resolve the AI-context drift properly: run `tekadept-sync-ai-config` to
-  generate `CLAUDE.md` from `docs/conventions.adoc` and the ADRs, replacing the
-  hand-written stopgap. This repo is the case study for why the file must be
-  generated — see MIGRATION-NOTES.adoc.
-* Close the gap between `just check` and CI: `.github/workflows/main.yaml`
-  enforces a 60% coverage floor with no local equivalent, so a green local
-  verdict does not imply a green CI. Port shuffle_up's `scripts/coverage.dart`
-  (a ratcheting gate that excludes generated code) and add a `coverage` recipe.
-
-== Next
-
-=== Harness gaps found during the template migration
-
-* `just analyze` is red: `dart run custom_lint` fails because `custom_lint` is
-  not a dependency here and the TekAdept layering-lint package does not exist
-  yet. Either add the dependency and the rule package, or supersede the
-  contract with an ADR — do not delete the line to go green.
-* `just bff-check` is red: `clang-format` and `clang-tidy` are not installed on
-  the development machine (`brew install llvm`). Once installed, expect a first
-  wave of formatting diffs across `bff/` since it has never been clang-formatted.
-* `bff/` has no `.clang-format` or `.clang-tidy` config committed, so even with
-  the binaries installed the recipes run against compiler defaults rather than
-  the TekAdept style.
-* [RESOLVED 2026-08-28] The BFF had no tests and no sanitizer build, so the
-  entire C++ side sat outside the harness. Addressed by
-  `specs/001-bff-test-harness/`: `just bff-test` and `just bff-test-asan` now
-  exist, `bff-check` runs the suite, and CI installs Drogon so the C++ rings
-  actually execute rather than erroring out. Remaining BFF gaps are specced but
-  unbuilt — see `specs/002-bff-durable-cache/`, `specs/003-bff-cost-caps/` and
-  `specs/004-bff-cache-metrics/`.
-* `bff/compile_commands.json`, `bff/metrics.jsonl`, `bff/uploads/` and
-  `bff/build/` are present in the working tree; check whether any of them should
-  be gitignored rather than tracked.
-
-=== Convention gaps
-
-* Rename `lib/blocs/` — it contains no BLoC code, only Riverpod notifiers. The
-  misleading name has already caused documented AI-context drift and is the
-  reason `AGENTS.md` exists. Either rename it (a refactor, deliberately not done
-  during the migration) or supersede ADR-0002 with an ADR that consciously
-  accepts the name.
-* No committed contract for the app↔BFF boundary, which `docs/conventions.adoc`
-  requires. The interface exists only as `RestaurantController` and
-  `Restaurant.fromBff` agreeing by hand. See ADR-0003.
-* `google_maps_flutter` is used directly in screen code rather than behind a
-  project-owned adapter, diverging from the ports-and-adapters rule.
-* `lib/` does not use the canonical four-layer structure. Adopt it, or write an
-  ADR accepting this project's structure as a documented exception.
-* Fold `AGENTS.md` into the generated AI-context pipeline. It is currently the
-  most accurate AI-facing document in the repo and is entirely hand-written,
-  which makes it the next candidate to drift.
-* Retire `docs/legacy/TEKADEPT_ARCHITECTURE_SPEC.md`. It is an org-wide standard
-  document that lives in a single project repo, and its "State Management |
-  BLoC/Cubit" row is the original source of this repo's documentation drift.
-  `tekadept-template`'s `docs/conventions.adoc` supersedes it.
-
-=== Launch prep (owner actions)
-
-// Recovered 2026-08-29 from the abandoned `chore/planning-docs-and-config`
-// branch (MY_TODOS.md, 2026-07-09) before deleting it. That file's other items
-// were verified DONE against the code and dropped rather than copied: the
-// Google Maps key is injected by deploy-web.yml, Firebase/Crashlytics are
-// initialised in lib/bootstrap.dart, and the Android signing secrets are in
-// place. Only what could not be verified as done is kept here.
-//
-// These are account/console tasks, not repo work, which is why they are here
-// rather than in GitHub Issues.
-
-* Publish a privacy policy and a support page. *Location data disclosure is
-  required* by both stores, so this gates submission, not just polish.
-* Create the store listings: App Store Connect (`com.tekadept.randoeats`) and
-  Google Play Console — content rating questionnaire, screenshots for
-  iPhone/iPad/Android, description and keywords.
-* Run `fastlane match adhoc` and `fastlane match appstore` for iOS signing.
-* Point `randoeats.com` at the web build. `api.randoeats.com` already resolves
-  to the BFF; the apex for the Flutter web app is unconfirmed.
-* AdMob console app and real ad unit IDs — *blocked on issue #87*, which asks
-  whether monetization is finished or stripped. Do not do this until that is
-  decided.
-
-=== Product work
-
-* Favourites screen — thumbs-up places. Confirmed absent from `lib/screens/`.
-* Sound effects (retro beeps). No audio dependency present.
-* Ads integration — `google_mobile_ads` is a dependency and referenced in one
-  file, but there is no ad presentation in the app.
-* Store readiness: iOS and Android build verification, web deployment to
-  randoeats.com, and App Store / Play Store submission.
-* Error, empty, and loading states with themed Googie messaging, per
-  `docs/legacy/MVP_PLAN.md` Phase 3.
-
-== Later
-
-* Raise the coverage floor once a local ratcheting gate exists.
-* Add a complexity ceiling. shuffle_up enforces McCabe ≤ 20 via
-  `scripts/complexity.dart`; this project has no complexity gate in CI at all,
-  and `docs/legacy-CLAUDE.md` referenced a `devforge metrics` invocation with a
-  33-violation baseline measured 2026-07-24 that is not enforced anywhere.
-* Bring the Maestro flows in `.maestro/` into CI.
-* Refresh or delete `docs/legacy/MVP_PLAN.md` — every Phase 1 and Phase 2 item
-  is still unchecked despite being implemented, so the document now
-  misinforms.
-
-== Icebox
-
-* Cross-device sync of ratings and picks. Contradicts ADR-0004 (no accounts,
-  device-local storage only) and would need a superseding ADR plus a
-  personal-data store to secure and disclose.
-* Aggregate/social recommendations built on rating data — impossible while
-  ratings never leave the device, same ADR-0004 constraint.
-* Persist the BFF cache (currently `InMemoryCache`, lost on restart) if Places
-  quota cost ever justifies it.
+This file deliberately contains no items. See
+xref:docs/adr/0005-github-issues-as-the-single-backlog.adoc[ADR-0005] for why
+it was retired: it duplicated the issue tracker within four days and every item
+in its "Harness gaps" section was obsolete within a week.

--- a/docs/adr/0005-github-issues-as-the-single-backlog.adoc
+++ b/docs/adr/0005-github-issues-as-the-single-backlog.adoc
@@ -1,0 +1,74 @@
+= ADR-0005: GitHub Issues as the single backlog, retiring BACKLOG.adoc
+:status: Accepted
+
+== Context
+
+The TekAdept template ships `BACKLOG.adoc`: a roadmap that travels with the
+repo, on the stated split that GitHub Issues hold discrete closeable work
+while the file holds "things that are planned but not yet tracked as discrete,
+closeable work items."
+
+That split did not survive contact with this project.
+
+*The distinction is mostly theoretical.* Reviewing the file's 28 items, nearly
+all of them were closeable: "add a coverage ratchet", "rename `lib/blocs/`",
+"publish a privacy policy", "bring Maestro into CI". Very little was genuinely
+roadmap-but-not-actionable. The category the file existed to hold was close to
+empty.
+
+*It duplicated Issues almost immediately.* Within four days of being written,
+`BACKLOG.adoc` contained an item duplicating issue #87 (ads integration), one
+duplicating `specs/002-bff-durable-cache/` (persist the BFF cache), one
+duplicating its own Launch-prep section (store readiness), and one contradicting
+a settled product decision (sound effects, which had been decided against).
+
+*It went stale faster than anyone would check it.* An audit on 2026-08-29 found
+that **all five** items in its "Harness gaps" section were obsolete: `just
+analyze` and `just bff-check` were described as red when both were green,
+`bff/.clang-format` and `bff/.clang-tidy` were described as missing when both
+were committed, and four files were described as wrongly tracked when all were
+already gitignored.
+
+This repository is the documented case study for what a second source of truth
+does — see the preamble of `CLAUDE.md` and `docs/legacy-CLAUDE.md`. A backlog
+file that drifts from the issue tracker is the same failure in a new place.
+
+== Decision
+
+*GitHub Issues are the single backlog.* Every piece of wanted work — features,
+bugs, chores, ideas — is an issue. Priority is expressed with labels
+(`priority:now`, `priority:next`, `priority:later`).
+
+Work that has been decided *against* is filed and immediately closed as
+`wontfix` with the reasoning, so the decision is searchable without occupying
+the open backlog. See issues #107 and #108, both closed against ADR-0004.
+
+`BACKLOG.adoc` is reduced to a pointer containing no items. A file with no
+content cannot drift, and it stops a future reader — human or agent — from
+concluding there is no roadmap and starting a new list.
+
+This diverges from `tekadept-template`. The divergence is recorded here rather
+than made silently, and the template should be revisited: if the same pattern
+holds in other projects, the template may be carrying a file that only ever
+becomes a second source of truth.
+
+== Consequences
+
+*Good.* One place to look. Issues carry state, labels, assignees, automatic
+closure from commits, and cross-links to PRs and specs, none of which an
+AsciiDoc file has. An issue is also the natural input to `/speckit-specify`,
+so the backlog feeds the spec workflow directly.
+
+*Cost.* The backlog is no longer readable from a clone with no network. For the
+two-tier agent workflow this matters slightly: the local tier reads the repo,
+and it can no longer read the roadmap. In practice the local tier works from
+packets and specs, not the backlog, so the loss is small.
+
+*Cost.* If the repository moves off GitHub, the backlog does not come with it.
+Accepted: the issue tracker is exportable, and the alternative demonstrably
+rots.
+
+*Not affected.* `docs/adr/` still holds decisions, `docs/specs/` still holds
+durable feature specs, `specs/NNN-*/` still holds Spec Kit working artifacts,
+and `docs/feature-inventory.adoc` still records what exists. None of those are
+backlogs.

--- a/docs/conventions.adoc
+++ b/docs/conventions.adoc
@@ -148,8 +148,20 @@ class, usually with a status enum), and `<feature>.dart` (a barrel export).
 `lib/blocs/discovery/` is the reference implementation.
 
 Do not "restore" BLoC on the strength of the directory name, and do not rename
-the directory as a side effect of other work — the rename is tracked in
-`BACKLOG.adoc`.
+the directory as a side effect of other work — the rename is tracked as
+GitHub issue #95.
+
+=== The backlog is GitHub Issues, not a file
+
+This project retired `BACKLOG.adoc`. Every piece of wanted work is a GitHub
+issue, prioritised with `priority:now` / `priority:next` / `priority:later`
+labels; work decided against is filed and closed as `wontfix` so the reasoning
+stays searchable. `BACKLOG.adoc` remains only as a pointer containing no items.
+
+This diverges from `tekadept-template`, which ships a populated `BACKLOG.adoc`.
+See ADR-0005: the file duplicated the issue tracker within four days and every
+item in its "Harness gaps" section was obsolete within a week. If the same
+pattern shows up in other TekAdept projects, the template should drop it too.
 
 === Layering differs from the shared rule
 
@@ -169,8 +181,8 @@ This repository is mixed: a Flutter app at the root and a Drogon BFF under
 Separately, `just check` is *weaker* than CI: `.github/workflows/main.yaml`
 enforces a 60% coverage floor through the `very_good_coverage` action, and
 this project has no local coverage-gate script for `just` to call. A green
-`just check` therefore does not imply a green CI. Closing that gap is a
-backlog item.
+`just check` therefore does not imply a green CI. Closing that gap is GitHub
+issue #93.
 
 === The app↔BFF boundary is not contract-first
 
@@ -184,4 +196,4 @@ client side agreeing by hand. See ADR-0003.
 is currently the most accurate AI-facing description of the project. It is
 hand-written, which makes it exactly the kind of duplicated document the
 generated-context rule exists to prevent. It was left in place because a tool
-consumes it; folding it into the generated pipeline is a backlog item.
+consumes it; folding it into the generated pipeline is GitHub issue #99.


### PR DESCRIPTION
## Description

Migrates all 28 `BACKLOG.adoc` items into GitHub Issues and retires the file, after auditing each item against the code.

**Result: 15 open issues, 2 filed-and-closed as `wontfix`, 9 dropped.**

## Why

The file made the argument itself. Within four days of being written it contained an item duplicating #87, one duplicating `specs/002-bff-durable-cache/`, one duplicating its own Launch-prep section, and one contradicting a settled decision.

And **all five** items in its "Harness gaps" section were obsolete within a week:

| Claim | Reality |
|---|---|
| `just analyze` is red | Green — verified by running it |
| `just bff-check` is red | Green — llvm installed, ratchet passing |
| No `bff/.clang-format` or `.clang-tidy` | Both committed |
| BFF has no tests or sanitizers | Resolved by spec 001 |
| Four files wrongly tracked | All gitignored |

This repo is already the case study for what a second source of truth does. A backlog file drifting from the issue tracker is that same failure in a new place.

## Dropped (9)

Five stale harness-gap items; "Ads integration" (duplicates #87); "Persist the BFF cache" (duplicates spec 002); "Store readiness" (duplicates Launch prep); "Sound effects" (contradicts the decision to keep the Googie feel visual).

## Filed (15) — #92–#106

`priority:now` — #92 generate `CLAUDE.md`, #93 local coverage ratchet, #94 privacy policy (blocks store submission)

`priority:next` — #95 `lib/blocs/` rename-or-ADR, #96 app↔BFF contract, #97 maps adapter, #98 structure ADR, #99 fold `AGENTS.md`, #100 retire the legacy arch spec, #101 favourites (decision first), #102 error/empty/loading audit, #103 store launch checklist

`priority:later` — #104 complexity ceiling, #105 Maestro in CI, #106 refresh/delete `MVP_PLAN.md`

## Closed as `wontfix` (2)

#107 cross-device sync and #108 social recommendations, both against ADR-0004 — filed and closed so the reasoning is searchable without sitting in the open backlog.

AdMob setup folded into #87 as a comment rather than filed, since it is meaningless until finish-or-strip is decided.

## What replaces the file

`BACKLOG.adoc` becomes a pointer with **no items** — a file with no content cannot drift, and it stops a future reader concluding there is no roadmap and starting a new list.

**ADR-0005** records the divergence from `tekadept-template` rather than making it silently, and recommends revisiting the template: if this pattern holds elsewhere, the template may be shipping a file that only ever becomes a second source of truth.

`docs/conventions.adoc` gains the new rule, and its three "this is a backlog item" references now point at #93, #95 and #99 specifically.

## Verification

`just check` green: 346 Dart tests, tidy ratchet at 112, 17 BFF tests.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9tP61i71QHPPPSL8z6dZe