### PR TITLE
docs(bff): correct the Nanode claim and record where the BFF actually runs

### DIFF
--- a/bff/README.md
+++ b/bff/README.md
@@ -53,7 +53,7 @@ cp config.example.json config.json
 |-----|---------|
 | `places_api_key` | Google Places API (New) key. **Restrict it by IP to the Linode.** |
 | `port` | Listen port (default 8848) |
-| `threads` | Drogon worker threads (1 is plenty on a Nanode) |
+| `threads` | Drogon worker threads (1 is plenty at this traffic) |
 | `cache_max_entries` | LRU bound (default 2000) — keeps RAM in check on the 1 GB box |
 | `nearby_ttl_seconds` / `details_ttl_seconds` | Cache TTLs (1h / 6h). Keep well under Google's 30-day caching limit. |
 | `metrics_log_path` | JSONL metrics file |
@@ -127,6 +127,26 @@ call counts, so a test can assert the thing that costs money — that Google was
 `InMemoryCache` takes an injectable clock so TTL expiry is exercised without
 waiting out a real 3600-second TTL. Production always uses the default steady
 clock.
+
+## Where this runs
+
+`randoeats-bff-prod` runs as a podman container on the **shared** TekAdept BFF
+host, alongside the other TekAdept BFF services, with Caddy as the sole public
+entry point. It is not a dedicated box: host port 8848 is reserved for randoeats
+specifically because ports must be unique across the tenants sharing that
+machine.
+
+The server inventory — addresses, sizes, what runs where — lives in the private
+`tekadept-bff` platform repo, not here. **This repository is public.**
+
+Two things that follow, and that the code used to get wrong:
+
+- The host is not memory-starved. An earlier comment in `services/InMemoryCache.h`
+  justified the entry cap by "the 1 GB Nanode"; the shared host has 4 GB, and all
+  co-located app containers together were using under 9 MB resident when measured
+  on 2026-08-29. The cap is still sensible, just not for that reason.
+- Port and hostname choices are platform-wide decisions, not local ones. Changing
+  8848 means changing the shared host's port map.
 
 ## Logging & rotation
 

--- a/bff/services/InMemoryCache.h
+++ b/bff/services/InMemoryCache.h
@@ -13,7 +13,7 @@
 /// Thread-safe, TTL + LRU bounded in-memory cache.
 ///
 /// Bounded at [maxEntries] (config `cache_max_entries`) with least-recently-used
-/// eviction so it can't exhaust memory on the 1 GB Nanode. Drogon serves
+/// eviction so it can't exhaust memory on the shared host. Drogon serves
 /// requests on multiple threads, so every operation is guarded by a mutex.
 class InMemoryCache : public ICache {
   public:


### PR DESCRIPTION
## Description

A Linode inventory export (2026-08-29) disproved a claim the code was carrying.

`bff/services/InMemoryCache.h` justified its entry cap by *"the 1 GB Nanode"*. **There is no Nanode.** `randoeats-bff-prod` runs on a shared `g6-standard-2` with **4 GB**, and when measured, all four co-located app containers together were using **under 9 MB** resident:

```
               total   used   free  buff/cache  available
Mem:            3915    574    661        2980       3341
Swap:            495      0    495
```

The cap is still sensible — the stated reason was false. It had already produced over-cautious sizing advice for the Redis work in `specs/002-bff-durable-cache/`.

## Changes

- `InMemoryCache.h` and `bff/README.md` no longer claim a Nanode
- New **"Where this runs"** section in `bff/README.md`: this is a *shared* host, port 8848 is reserved because host ports must be unique across tenants, and changing it is a platform-wide decision. None of that was recorded in this repo.

## Deliberately not added here

**The server inventory itself.** This repository is **public**; a list of every server with its size and address does not belong in it. It now lives in the private `tekadept-bff` platform repo, next to the existing host port map, as a dated snapshot with the `linode-cli` command to regenerate it.

## Verification

`just check` green.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9tP61i71QHPPPSL8z6dZe