### PR TITLE
fix(bff): restore controller route registration (production 404)

### DIFF
--- a/bff/CMakeLists.txt
+++ b/bff/CMakeLists.txt
@@ -13,9 +13,16 @@ find_package(Drogon CONFIG REQUIRED)
 # build lives in its own build directory (see `just bff-test-asan`).
 option(ENABLE_SANITIZERS "Build with AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 
-# Everything except main(), so the test binary can link the real code. The
-# shipped executable's contents are unchanged: it is this library plus main.cc.
-add_library(randoeats_bff_lib STATIC
+# Everything except main(), so the test binary can link the real code.
+#
+# OBJECT, not STATIC. Drogon controllers self-register through static
+# initialisers in their translation unit. In a STATIC library the linker drops
+# any object file the executable does not reference a symbol from -- main.cc
+# never names RestaurantController -- so the registration disappears and Drogon
+# answers 404 on every controller route while /api/v1/health (registered
+# directly in main.cc) keeps working. That shipped to production on 2026-08-29.
+# An OBJECT library links every object into the consumer, preserving them.
+add_library(randoeats_bff_lib OBJECT
   controllers/RestaurantController.cc
   services/GooglePlacesClient.cc
   services/PlacesService.cc
@@ -57,5 +64,11 @@ if(ENABLE_SANITIZERS)
 endif()
 
 add_test(NAME randoeats_bff_tests COMMAND randoeats_bff_tests)
+
+# Runs against the built executable, which the unit suite cannot do: it is the
+# only thing that proves the controllers survived the link. See the header of
+# smoke_routes.sh for the production outage that motivated it.
+add_test(NAME randoeats_bff_routes
+         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/smoke_routes.sh $<TARGET_FILE:randoeats_bff>)
 
 endif()

--- a/bff/tests/smoke_routes.sh
+++ b/bff/tests/smoke_routes.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Route-registration smoke test, run by CTest against the BUILT EXECUTABLE.
+#
+# The unit suite cannot catch what this catches. Drogon controllers register
+# themselves through static initialisers in their translation unit; when the
+# controller sources were built into a STATIC library, the linker dropped the
+# object file (main.cc references no symbol from it) and every controller route
+# vanished while /api/v1/health -- registered directly in main.cc -- kept
+# answering. `just check` was green, the image built, it deployed, and the app
+# 404'd in production on 2026-08-29.
+#
+# The unit tests link the same objects, so registration always works there.
+# Only the real binary can prove the routes survived the link.
+#
+# Usage: smoke_routes.sh <path-to-randoeats_bff>
+
+set -uo pipefail
+
+BIN="${1:?usage: smoke_routes.sh <path-to-randoeats_bff>}"
+PORT=$(( 20000 + RANDOM % 20000 ))
+TMP="$(mktemp -d)"
+trap 'kill "${PID:-0}" 2>/dev/null; rm -rf "$TMP"' EXIT
+
+cat > "$TMP/config.json" <<CFG
+{
+  "places_api_key": "SMOKE-TEST-NOT-A-REAL-KEY",
+  "port": $PORT,
+  "threads": 1,
+  "cache_max_entries": 10,
+  "nearby_ttl_seconds": 60,
+  "details_ttl_seconds": 60,
+  "metrics_log_path": "$TMP/metrics.jsonl",
+  "allowed_origins": ["http://localhost"]
+}
+CFG
+
+"$BIN" "$TMP/config.json" >"$TMP/server.log" 2>&1 &
+PID=$!
+
+for _ in $(seq 1 50); do
+    if curl -fsS -m 1 "http://127.0.0.1:$PORT/api/v1/health" >/dev/null 2>&1; then break; fi
+    kill -0 "$PID" 2>/dev/null || { echo "FAIL: server exited during startup"; cat "$TMP/server.log"; exit 1; }
+    sleep 0.2
+done
+
+fail=0
+
+# A registered route must NOT answer 404. It may answer 502 (the fake key makes
+# the upstream call fail) -- that is a pass: it proves the request reached our
+# controller instead of Drogon's default handler.
+check_route() {
+    local path="$1" name="$2"
+    local code
+    code=$(curl -s -o /dev/null -m 20 -w '%{http_code}' "http://127.0.0.1:$PORT$path")
+    if [ "$code" = "404" ]; then
+        echo "FAIL: $name is not registered ($path returned 404 -- Drogon's default handler)"
+        fail=1
+    else
+        echo "ok: $name registered ($path -> $code)"
+    fi
+}
+
+check_route "/api/v1/health" "health"
+check_route "/api/v1/restaurants/nearby?lat=33.7&lng=-117.8&radius=1000&max_results=1" "nearby"
+check_route "/api/v1/restaurants/smoke-test-place-id" "details"
+
+exit "$fail"


### PR DESCRIPTION
## Production is down and this is the fix

Every restaurant endpoint has been returning **Drogon's default 404** since the deploy of #90. `/api/v1/health` kept answering, which is why it looked healthy from the outside.

```
$ curl https://api.randoeats.com/api/v1/restaurants/nearby?lat=33.7458&lng=-117.8261
<html><head><title>404 Not Found</title></head>
<body>...<center>drogon/1.9.13</center></body></html>
```

That page is Drogon saying "no route matched" — not our JSON error.

## Cause, and it is mine

#90 split the BFF sources into a **STATIC** library so tests could link them. Drogon controllers register themselves through **static initialisers** in their translation unit, and in a static library the linker drops any object file the executable references no symbol from. `main.cc` never names `RestaurantController`, so the object was discarded — and every `ADD_METHOD_TO` route with it.

`/api/v1/health` survived only because `main.cc` registers it directly via `app().registerHandler`.

## Fix

`OBJECT` library instead of `STATIC`. An object library links every object into the consumer, so the initialisers survive. The test binary is unaffected.

## Why nothing caught it

The unit suite calls `PlacesService` directly and never exercises an HTTP route. Neither `just check` nor the `check` workflow ever asks the built server whether its routes exist. Green local verdict, green CI, green image build, broken product — the third time this session that a check passed while something real was wrong, and the second caused by a gap between what is built and what is verified.

## The guard

`bff/tests/smoke_routes.sh`, run by CTest **against the built executable**: starts the real binary on a random port with a throwaway config and asserts `health`, `nearby` and `details` do not answer 404. A 502 passes — the fake key makes the upstream call fail, which still proves the request reached our controller.

**Verified by reverting to `STATIC`:**

```
ok:   health registered (/api/v1/health -> 200)
FAIL: nearby is not registered (... returned 404 -- Drogon default handler)
FAIL: details is not registered (... returned 404 -- Drogon default handler)
```

Exactly the production symptom. Passes on the fix.

## Verification

- Ran the fixed binary locally: `nearby` returns `{"error":"upstream error"}` 502 from our controller
- Confirmed the broken binary contains **zero** occurrences of the route string; the fixed one contains it
- `just check` green: 346 Dart tests, tidy ratchet at 112, **2** BFF test targets now

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [x] 🧪 Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9tP61i71QHPPPSL8z6dZe