### PR TITLE
feat(bff): expose the cache decision as an X-Cache header

### DIFF
--- a/bff/controllers/RestaurantController.cc
+++ b/bff/controllers/RestaurantController.cc
@@ -31,6 +31,13 @@ HttpResponsePtr jsonResponse(const ServiceResult& result) {
     if (result.ttlSeconds > 0) {
         resp->addHeader("Cache-Control", "public, max-age=" + std::to_string(result.ttlSeconds));
     }
+    // Surface the cache decision the service already made. Without it, HIT vs
+    // MISS is only inferable from response time in the Caddy access log
+    // (~1ms vs ~100-300ms), which makes cache efficiency awkward to measure and
+    // impossible to assert in a test. See specs/004-bff-cache-metrics/.
+    if (!result.cache.empty()) {
+        resp->addHeader("X-Cache", result.cache);
+    }
     return resp;
 }
 

--- a/bff/tests/smoke_routes.sh
+++ b/bff/tests/smoke_routes.sh
@@ -61,8 +61,23 @@ check_route() {
     fi
 }
 
+# The cache decision must be visible on the wire, not just in the metrics log.
+check_cache_header() {
+    local path="$1"
+    local hdr
+    hdr=$(curl -s -o /dev/null -m 20 -D - "http://127.0.0.1:$PORT$path" \
+          | tr -d '\r' | grep -i '^x-cache:' | head -1)
+    if [ -z "$hdr" ]; then
+        echo "FAIL: no X-Cache header on $path"
+        fail=1
+    else
+        echo "ok: cache decision exposed ($hdr)"
+    fi
+}
+
 check_route "/api/v1/health" "health"
 check_route "/api/v1/restaurants/nearby?lat=33.7&lng=-117.8&radius=1000&max_results=1" "nearby"
 check_route "/api/v1/restaurants/smoke-test-place-id" "details"
+check_cache_header "/api/v1/restaurants/nearby?lat=33.7&lng=-117.8&radius=1000&max_results=1"
 
 exit "$fail"

--- a/specs/004-bff-cache-metrics/spec.md
+++ b/specs/004-bff-cache-metrics/spec.md
@@ -5,6 +5,27 @@
 **Status**: Draft
 **Input**: `MetricsLogger` writes `metrics.jsonl` and the Caddy vhost logs access specifically so HIT (~1ms) can be split from MISS (~100-300ms), but nothing turns either into a hit rate, a call count, or an estimated spend. Without those numbers, both TTLs and the caps in 003 can only be guessed at.
 
+## Update 2026-08-29 — the cache decision is now on the wire
+
+Since this spec was written, `RestaurantController` sets an **`X-Cache: HIT|MISS`**
+response header (added while fixing the route-registration outage). Previously
+HIT vs MISS was only inferable from response time in the Caddy access log
+(~1ms vs ~100-300ms), which is what the framing below assumes.
+
+Two consequences for this feature:
+
+- FR-001's aggregation gets a directly observable input instead of a latency
+  heuristic, and SC-001's cross-check against the access log becomes an exact
+  comparison rather than an approximate one.
+- The smoke test in `bff/tests/smoke_routes.sh` now asserts the header exists,
+  so the signal this feature depends on cannot silently disappear.
+
+Note also that `scripts/randoeats-cache-report.sh` already exists in the private
+`tekadept-bff` platform repo, alongside a monitoring dashboard. **Read it before
+implementing this spec** — part of the work may already be done there, and the
+right home for the reporting may be that dashboard rather than an endpoint on
+this BFF, since the dashboard already spans all four co-located tenants.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Hit rate is a number I can read (Priority: P1)


### PR DESCRIPTION
## Description

The BFF already knows whether a response was a HIT or a MISS — `PlacesService` returns it on `ServiceResult`, and the metrics advice records it — but nothing put it on the wire. From outside, cache behaviour was only inferable from **response time** in the Caddy access log (~1ms vs ~100-300ms): a heuristic, not a fact, and impossible to assert in a test.

`jsonResponse` now sets `X-Cache: HIT|MISS` whenever the service reported one. Two lines, no behaviour change, no extra work per request.

## Guard

`smoke_routes.sh` asserts the header is present, so this signal cannot silently disappear the way the routes did:

```
ok: health registered (/api/v1/health -> 200)
ok: nearby registered (... -> 502)
ok: details registered (... -> 502)
ok: cache decision exposed (x-cache: MISS)
```

**Known limit:** the smoke test runs with a throwaway API key, so no request ever populates the cache and it can only ever observe `MISS`. The HIT path stays covered by the `PlacesService` unit tests.

## Spec 004 updated

Its framing assumed this data was unavailable. Two changes:

- Aggregation now has a directly observable input instead of a latency heuristic, and SC-001's cross-check against the access log becomes exact rather than approximate.
- It now points at `scripts/randoeats-cache-report.sh` and the monitoring dashboard in the private `tekadept-bff` repo. **Part of 004 may already be built there**, and that dashboard may be the better home for it, since it already spans all four co-located tenants rather than just this one.

## Verification

`just check` green: 346 Dart tests, tidy ratchet at 112, both BFF test targets.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [x] 🧪 Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9tP61i71QHPPPSL8z6dZe