### PR TITLE
fix(app): apply the wine filter client-side and offer the $$$$ price level

### DIFF
--- a/lib/blocs/discovery/discovery_notifier.dart
+++ b/lib/blocs/discovery/discovery_notifier.dart
@@ -225,6 +225,9 @@ class DiscoveryNotifier extends Notifier<DiscoveryState> {
     if (filters.servesBeer) {
       result = result.where((r) => r.servesBeer ?? false).toList();
     }
+    if (filters.servesWine) {
+      result = result.where((r) => r.servesWine ?? false).toList();
+    }
     if (filters.outdoorSeating) {
       result = result.where((r) => r.outdoorSeating ?? false).toList();
     }

--- a/lib/screens/results/results_screen.dart
+++ b/lib/screens/results/results_screen.dart
@@ -300,7 +300,7 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
                         return Wrap(
                           spacing: 8,
                           children: [
-                            for (final level in const [1, 2, 3])
+                            for (final level in const [1, 2, 3, 4])
                               ChoiceChip(
                                 key: ValueKey('resultsTunePriceChip_$level'),
                                 label: Text(r'$' * level),

--- a/lib/widgets/filter_chip_bar.dart
+++ b/lib/widgets/filter_chip_bar.dart
@@ -114,7 +114,7 @@ class FilterChipBar extends ConsumerWidget {
                           : f.copyWith(minRating: 4),
                     ),
                   ),
-                  for (final level in const [1, 2, 3])
+                  for (final level in const [1, 2, 3, 4])
                     _FacetChip(
                       key: ValueKey('resultsPriceChip_$level'),
                       label: r'$' * level,

--- a/test/blocs/discovery/discovery_notifier_test.dart
+++ b/test/blocs/discovery/discovery_notifier_test.dart
@@ -536,6 +536,7 @@ void main() {
         isOpen: true,
         types: ['restaurant', 'mexican_restaurant'],
         servesBeer: true,
+        servesWine: true,
         outdoorSeating: true,
         goodForGroups: true,
         hasParking: true,
@@ -551,6 +552,7 @@ void main() {
         isOpen: true,
         types: ['restaurant', 'sushi_restaurant'],
         servesBeer: false,
+        servesWine: false,
         outdoorSeating: false,
       );
       const burgerBeer = Restaurant(
@@ -611,6 +613,14 @@ void main() {
         expect(await runWith(const SpotFilters(servesBeer: true)), {
           'beer_mex',
           'burger',
+        });
+      });
+
+      test('servesWine excludes both false and unknown', () async {
+        // burger leaves servesWine null. Unknown can not be confirmed, so it
+        // is excluded exactly as an explicit false is — matching servesBeer.
+        expect(await runWith(const SpotFilters(servesWine: true)), {
+          'beer_mex',
         });
       });
 

--- a/test/widgets/filter_chip_bar_test.dart
+++ b/test/widgets/filter_chip_bar_test.dart
@@ -72,6 +72,15 @@ void main() {
       expect(container.read(activeFiltersProvider).priceLevels, {2});
     });
 
+    testWidgets('the fourth price level is offered and toggles', (
+      tester,
+    ) async {
+      final container = await pump(tester);
+      await tester.tap(find.byKey(const ValueKey('resultsPriceChip_4')));
+      await tester.pump();
+      expect(container.read(activeFiltersProvider).priceLevels, {4});
+    });
+
     testWidgets('save-spot star is hidden without onSaveSpot', (tester) async {
       final container = await pump(tester);
       container.read(activeFiltersProvider.notifier).toggleCuisine('mexican');


### PR DESCRIPTION
## Description

Two independent filter defects from the filter design review. Both are client-side only — the BFF already handled each case correctly.

### #118 — `servesWine` was sent upstream but never applied locally

`SpotFilters.servesWine` goes out as `wine=true` (`places_service.dart:105`), but `_applyFilters` had branches for `servesBeer`, `outdoorSeating`, `goodForGroups` and `hasParking` only. Every other atmosphere chip filtered twice — server and client — while wine filtered once, so a place whose wine attribute was unknown survived where the equivalent beer chip would have dropped it.

I checked the data layer before touching the UI: `Restaurant.servesWine` is populated by both `fromBff` and the legacy parser, and the BFF filters wine at `PlacesService.cc:190`. Only the client branch was missing.

### #119 — `$$$$` was unreachable from either price control

Both price surfaces iterated `const [1, 2, 3]`, while `_priceLevelInt` maps `$$$$` → 4 and `SpotFilters.priceLevels` is documented as 1–4. Any active price filter therefore excluded every `$$$$` restaurant with no control able to include one — they were visible only when price filtering was off entirely.

Nothing else needed changing: `label: r'$' * level` renders it, `_priceLevelLabel` and `_priceLevelInt` already map 4 in both directions, and the BFF's `price` parameter is documented as a CSV of 1..4.

## Tests

- `servesWine excludes both false and unknown` — the sushi fixture gets an explicit `false` and the burger is left `null`, so both exclusion paths are covered rather than only the explicit one.
- `the fourth price level is offered and toggles` — taps `resultsPriceChip_4`.

`just check` green: format clean, analyze clean, **348 Dart tests** (up from 346), BFF tests pass, clang-tidy ratchet holding at 112.

## Not in scope

Quick Tune still offers only Beer among the atmosphere filters — no Wine, Patio, Parking or Group. That asymmetry is #123's territory (delete those duplicated controls rather than complete them), so it is deliberately untouched here.

Closes #118
Closes #119

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [x] 🧪 Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeoVLn9cdnPfTpYQzXfg1X
